### PR TITLE
Fix how we return loid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ FROM python:3.8
 COPY --from=thrift /usr/local/bin/thrift /usr/local/bin/thrift
 
 WORKDIR /src
-COPY lib/py/requirements*.txt .
+COPY lib/py/requirements*.txt ./
 RUN pip install -r requirements.txt
 CMD ["/bin/bash"]

--- a/lib/py/tests/edge_context_tests.py
+++ b/lib/py/tests/edge_context_tests.py
@@ -199,7 +199,8 @@ class EdgeContextTests(unittest.TestCase):
 
         self.assertEqual(request_context.user.id, "t2_example")
         self.assertTrue(request_context.user.is_logged_in)
-        self.assertEqual(request_context.user.loid, self.LOID_ID)
+        # For logged in user, we expect loid returns logged in user id
+        self.assertEqual(request_context.user.loid, "t2_example")
         self.assertEqual(request_context.user.cookie_created_ms, self.LOID_CREATED_MS)
         self.assertEqual(request_context.user.roles, set())
         self.assertFalse(request_context.user.has_role("test"))


### PR DESCRIPTION
This is basically migrated
https://github.com/reddit/baseplate.py/pull/433.

We should return LoID in this order (fallback to the next one if it's
empty):

1. The logged in user id from the JWT token
2. The loid from the thrift payload
3. The loid from the JWT token