### PR TITLE
Fix naming of context variable

### DIFF
--- a/reddit_edgecontext/__init__.py
+++ b/reddit_edgecontext/__init__.py
@@ -444,8 +444,8 @@ class EdgeContext:
         :param context: request context to attach this to
 
         """
-        context.request_context = self
-        context.raw_request_context = self._header
+        context.edge_context = self
+        context.raw_edge_context = self._header
 
 
 class EdgeContextFactory(BaseEdgeContextFactory):


### PR DESCRIPTION
This got renamed in baseplate but not here.