### PR TITLE
py: Add exception handling in loid implementation

### DIFF
--- a/lib/py/reddit_edgecontext/__init__.py
+++ b/lib/py/reddit_edgecontext/__init__.py
@@ -290,9 +290,13 @@ class User(NamedTuple):
             return self.loid_
 
         # Finally, return loid from authentication token
-        loid = self.authentication_token.loid
-        if loid:
-            return loid
+        try:
+            loid = self.authentication_token.loid
+            if loid:
+                return loid
+        except NoAuthenticationError:
+            # self.authentication_token could be an InvalidAuthenticationToken
+            pass
 
         return ""
 


### PR DESCRIPTION
The authentication_token could be invalid, which would raise
NoAuthenticationError when trying to access its loid, so handle that
case properly.