### PR TITLE
Add Request ID to EdgeContext

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,28 @@ FROM python:3.8
 COPY --from=thrift /usr/local/bin/thrift /usr/local/bin/thrift
 COPY --from=go /usr/local/go /usr/local/go
 
-ENV GOPATH=/root/go
+RUN mkdir /opt/go
+ENV GOPATH=/opt/go
 ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 RUN go install golang.org/x/lint/golint@latest
 
 WORKDIR /src
 COPY lib/py/requirements*.txt ./
 RUN pip install -r requirements.txt
+
+# Permission fixes for running as a test environment.
+# Assumption: This docker image is not used outside build and test
+# environments.
+# $GOPATH: conflicts with local volume mount of /src:
+#    This mount provides a live code editing environment.
+#    It is not accessed as root (must use the host's UID namespace to write
+#    back to the volume) so to have a single process reading $GOPATH and /src
+#    simultaneously we need open permissions.
+# $HOME/.cache:
+#    go expects $HOME/.cache to be writable but in the recommended test
+#    environment, $HOME is /, so pre-create .cache too.
+
+RUN mkdir /.cache
+RUN chmod a+rwX -R $GOPATH /.cache
+
 CMD ["/bin/bash"]

--- a/edgecontext.thrift
+++ b/edgecontext.thrift
@@ -91,6 +91,19 @@ struct Geolocation {
     1: CountryCode country_code
 }
 
+/** Unique identifier of this Edge Request
+
+This model is a component of the "Edge-Request" header.  You should not need to
+interact with this model directly, but rather through the EdgeRequestContext
+interface provided by baseplate.
+
+*/
+struct RequestId {
+    /** The id of this Edge Request, in the most human-readable format.
+    */
+    1: string readable_id
+}
+
 /** Container model for the Edge-Request context header.
 
 Baseplate will automatically parse this from the "Edge-Request" header and
@@ -106,4 +119,5 @@ struct Request {
     4: Device device;
     5: OriginService origin_service;
     6: Geolocation geolocation;
+    7: optional RequestId request_id;
 }

--- a/lib/go/edgecontext/edgecontext.go
+++ b/lib/go/edgecontext/edgecontext.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/gofrs/uuid"
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/secrets"
@@ -131,7 +130,7 @@ type NewArgs struct {
 
 	CountryCode string
 
-	RequestID uuid.UUID
+	RequestID string
 }
 
 // New creates a new EdgeRequestContext from scratch.
@@ -169,9 +168,9 @@ func New(ctx context.Context, impl *Impl, args NewArgs) (*EdgeRequestContext, er
 			CountryCode: ecthrift.CountryCode(args.CountryCode),
 		}
 	}
-	if args.RequestID != uuid.Nil {
+	if args.RequestID != "" {
 		request.RequestID = &ecthrift.RequestId{
-			ReadableID: args.RequestID.String(),
+			ReadableID: args.RequestID,
 		}
 	}
 	request.AuthenticationToken = ecthrift.AuthenticationToken(args.AuthToken)
@@ -220,10 +219,7 @@ func FromHeader(ctx context.Context, header string, impl *Impl) (*EdgeRequestCon
 		raw.CountryCode = string(request.Geolocation.CountryCode)
 	}
 	if request.RequestID != nil {
-		rid, err := uuid.FromString(request.RequestID.ReadableID)
-		if err == nil {
-			raw.RequestID = rid
-		}
+		raw.RequestID = request.RequestID.ReadableID
 	}
 	return &EdgeRequestContext{
 		impl:   impl,

--- a/lib/go/edgecontext/edgecontext_test.go
+++ b/lib/go/edgecontext/edgecontext_test.go
@@ -15,21 +15,35 @@ import (
 
 const (
 	// copied from https://github.com/reddit/edgecontext.py/blob/420e58728ee7085a2f91c5db45df233142b251f9/tests/edge_context_tests.py#L55-L58
-	headerWithNoAuth      = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x00"
-	headerWithValidAuth   = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x00"
-	headerWithExpiredAuth = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoxMjYyMzA0MDAwfQ.iUD0J2blW-HGtH86s66msBXymCRCgyxAZJ6xX2_SXD-kegm-KjOlIemMWFZtsNv9DJI147cNP81_gssewvUnhIHLVvXWCTOROasXbA9Yf2GUsjxoGSB7474ziPOZquAJKo8ikERlhOOVk3r4xZIIYCuc4vGZ7NfqFxjDGKAWj5Tt4VUiWXK1AdxQck24GyNOSXs677vIJnoD8EkgWqNuuwY-iFOAPVcoHmEuzhU_yUeQnY8D-VztJkip5-YPEnuuf-dTSmPbdm9ZTOP8gjTsG0Sdvb9NdLId0nEwawRy8CfFEGQulqHgd1bqTm25U-NyXQi7zroi1GEdykZ3w9fVNQ\x00"
-	headerWithAnonAuth    = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xc0eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhbm9ueW1vdXMiXSwic3ViIjpudWxsLCJleHAiOjI1MjQ2MDgwMDB9.gQDiVzOUh70mKKK-YBTnLHWBOEuQyRllEE1-EIMfy3x5K8PsH9FB6Oy9S5HbILjfGFNrIBeux9HyW6hBDikoZDhn5QWyPNitL1pzMNONGGrXzSfaDoDbFy4MLD03A7zjG3qWBn_wLjgzUXX6qVX6W_gWO7dMqrq0iFvEegue-xQ1HGiXfPgnTrXRRovUO3JHy1LcZsmOjltYj5VGUTWXodBM8ObKEealDxg8yskEPy0IuujNMmb9eIyuHB8Ozzpg-lr790lxP37s5HCf18vrZ-IhRmLcLCqm5WSFyq_Ld2ByblBKL9pPst1AZYZTXNRIqovTAqr6v0-xjUeJ1iho9A\x00"
+	headerWithNoAuth            = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x00"
+	headerWithValidAuth         = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x0b\x00\x01\x00\x00\x00\x24" + expectedRequestIDString + "\x00\x00"
+	headerWithExpiredAuth       = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoxMjYyMzA0MDAwfQ.iUD0J2blW-HGtH86s66msBXymCRCgyxAZJ6xX2_SXD-kegm-KjOlIemMWFZtsNv9DJI147cNP81_gssewvUnhIHLVvXWCTOROasXbA9Yf2GUsjxoGSB7474ziPOZquAJKo8ikERlhOOVk3r4xZIIYCuc4vGZ7NfqFxjDGKAWj5Tt4VUiWXK1AdxQck24GyNOSXs677vIJnoD8EkgWqNuuwY-iFOAPVcoHmEuzhU_yUeQnY8D-VztJkip5-YPEnuuf-dTSmPbdm9ZTOP8gjTsG0Sdvb9NdLId0nEwawRy8CfFEGQulqHgd1bqTm25U-NyXQi7zroi1GEdykZ3w9fVNQ\x0c\x00\x07\x00\x00"
+	headerWithAnonAuth          = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xc0eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhbm9ueW1vdXMiXSwic3ViIjpudWxsLCJleHAiOjI1MjQ2MDgwMDB9.gQDiVzOUh70mKKK-YBTnLHWBOEuQyRllEE1-EIMfy3x5K8PsH9FB6Oy9S5HbILjfGFNrIBeux9HyW6hBDikoZDhn5QWyPNitL1pzMNONGGrXzSfaDoDbFy4MLD03A7zjG3qWBn_wLjgzUXX6qVX6W_gWO7dMqrq0iFvEegue-xQ1HGiXfPgnTrXRRovUO3JHy1LcZsmOjltYj5VGUTWXodBM8ObKEealDxg8yskEPy0IuujNMmb9eIyuHB8Ozzpg-lr790lxP37s5HCf18vrZ-IhRmLcLCqm5WSFyq_Ld2ByblBKL9pPst1AZYZTXNRIqovTAqr6v0-xjUeJ1iho9A\x0c\x00\x07\x00\x00"
+	headerWithReadableRequestID = ("\x0c\x00\x01\x00\x0c\x00\x02\x00\x0c\x00\x04\x00\x0c\x00\x05\x00\x0c\x00\x06\x00" +
+		// struct 7: request_id
+		"\x0c\x00\x07" +
+		// string 1: readable_id
+		"\x0b\x00\x01" +
+		// length == 36, payload
+		"\x00\x00\x00\x24" + expectedRequestIDString +
+		// end of struct
+		"\x00" +
+		// end of struct
+		"\x00")
 )
 
 const (
-	expectedCountryCode = "OK"
-	expectedDeviceID    = "becc50f6-ff3d-407a-aa49-fa49531363be"
-	expectedLoID        = "t2_deadbeef"
-	expectedOrigin      = "baseplate"
-	expectedSessionID   = "beefdead"
+	expectedCountryCode     = "OK"
+	expectedDeviceID        = "becc50f6-ff3d-407a-aa49-fa49531363be"
+	expectedLoID            = "t2_deadbeef"
+	expectedOrigin          = "baseplate"
+	expectedSessionID       = "beefdead"
+	expectedRequestIDString = "2adaff94-9067-4de0-a00b-79fded5cff9e"
 
 	emptyDeviceID = "00000000-0000-0000-0000-000000000000"
 )
+
+var expectedRequestID = uuid.Must(uuid.FromString(expectedRequestIDString))
 
 var expectedCookieTime = time.Unix(100, 0)
 
@@ -217,6 +231,7 @@ func TestNew(t *testing.T) {
 			DeviceID:          expectedDeviceID,
 			CountryCode:       expectedCountryCode,
 			OriginServiceName: expectedOrigin,
+			RequestID:         expectedRequestID,
 		},
 	)
 	if err != nil {
@@ -649,6 +664,24 @@ func TestFromHeader(t *testing.T) {
 					)
 				},
 			)
+		},
+	)
+
+	t.Run(
+		"request-id",
+		func(t *testing.T) {
+			e, err := edgecontext.FromHeader(context.Background(), headerWithReadableRequestID, globalTestImpl)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if e.RequestID() != expectedRequestID {
+				t.Errorf(
+					"Expected request id %q, got %q",
+					expectedRequestID,
+					e.RequestID(),
+				)
+			}
 		},
 	)
 }

--- a/lib/go/edgecontext/edgecontext_test.go
+++ b/lib/go/edgecontext/edgecontext_test.go
@@ -16,7 +16,7 @@ import (
 const (
 	// copied from https://github.com/reddit/edgecontext.py/blob/420e58728ee7085a2f91c5db45df233142b251f9/tests/edge_context_tests.py#L55-L58
 	headerWithNoAuth            = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x00"
-	headerWithValidAuth         = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x0b\x00\x01\x00\x00\x00\x24" + expectedRequestIDString + "\x00\x00"
+	headerWithValidAuth         = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x0b\x00\x01\x00\x00\x00\x24" + expectedRequestID + "\x00\x00"
 	headerWithExpiredAuth       = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoxMjYyMzA0MDAwfQ.iUD0J2blW-HGtH86s66msBXymCRCgyxAZJ6xX2_SXD-kegm-KjOlIemMWFZtsNv9DJI147cNP81_gssewvUnhIHLVvXWCTOROasXbA9Yf2GUsjxoGSB7474ziPOZquAJKo8ikERlhOOVk3r4xZIIYCuc4vGZ7NfqFxjDGKAWj5Tt4VUiWXK1AdxQck24GyNOSXs677vIJnoD8EkgWqNuuwY-iFOAPVcoHmEuzhU_yUeQnY8D-VztJkip5-YPEnuuf-dTSmPbdm9ZTOP8gjTsG0Sdvb9NdLId0nEwawRy8CfFEGQulqHgd1bqTm25U-NyXQi7zroi1GEdykZ3w9fVNQ\x0c\x00\x07\x00\x00"
 	headerWithAnonAuth          = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xc0eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhbm9ueW1vdXMiXSwic3ViIjpudWxsLCJleHAiOjI1MjQ2MDgwMDB9.gQDiVzOUh70mKKK-YBTnLHWBOEuQyRllEE1-EIMfy3x5K8PsH9FB6Oy9S5HbILjfGFNrIBeux9HyW6hBDikoZDhn5QWyPNitL1pzMNONGGrXzSfaDoDbFy4MLD03A7zjG3qWBn_wLjgzUXX6qVX6W_gWO7dMqrq0iFvEegue-xQ1HGiXfPgnTrXRRovUO3JHy1LcZsmOjltYj5VGUTWXodBM8ObKEealDxg8yskEPy0IuujNMmb9eIyuHB8Ozzpg-lr790lxP37s5HCf18vrZ-IhRmLcLCqm5WSFyq_Ld2ByblBKL9pPst1AZYZTXNRIqovTAqr6v0-xjUeJ1iho9A\x0c\x00\x07\x00\x00"
 	headerWithReadableRequestID = ("\x0c\x00\x01\x00\x0c\x00\x02\x00\x0c\x00\x04\x00\x0c\x00\x05\x00\x0c\x00\x06\x00" +
@@ -25,7 +25,7 @@ const (
 		// string 1: readable_id
 		"\x0b\x00\x01" +
 		// length == 36, payload
-		"\x00\x00\x00\x24" + expectedRequestIDString +
+		"\x00\x00\x00\x24" + expectedRequestID +
 		// end of struct
 		"\x00" +
 		// end of struct
@@ -33,17 +33,15 @@ const (
 )
 
 const (
-	expectedCountryCode     = "OK"
-	expectedDeviceID        = "becc50f6-ff3d-407a-aa49-fa49531363be"
-	expectedLoID            = "t2_deadbeef"
-	expectedOrigin          = "baseplate"
-	expectedSessionID       = "beefdead"
-	expectedRequestIDString = "2adaff94-9067-4de0-a00b-79fded5cff9e"
+	expectedCountryCode = "OK"
+	expectedDeviceID    = "becc50f6-ff3d-407a-aa49-fa49531363be"
+	expectedLoID        = "t2_deadbeef"
+	expectedOrigin      = "baseplate"
+	expectedSessionID   = "beefdead"
+	expectedRequestID   = "2adaff94-9067-4de0-a00b-79fded5cff9e"
 
 	emptyDeviceID = "00000000-0000-0000-0000-000000000000"
 )
-
-var expectedRequestID = uuid.Must(uuid.FromString(expectedRequestIDString))
 
 var expectedCookieTime = time.Unix(100, 0)
 

--- a/lib/go/edgecontext/req_context.go
+++ b/lib/go/edgecontext/req_context.go
@@ -164,3 +164,8 @@ type OriginService struct {
 func (os OriginService) Name() string {
 	return os.raw.OriginServiceName
 }
+
+// RequestID is id of this request.
+func (e *EdgeRequestContext) RequestID() uuid.UUID {
+	return e.raw.RequestID
+}

--- a/lib/go/edgecontext/req_context.go
+++ b/lib/go/edgecontext/req_context.go
@@ -165,7 +165,7 @@ func (os OriginService) Name() string {
 	return os.raw.OriginServiceName
 }
 
-// RequestID is id of this request.
-func (e *EdgeRequestContext) RequestID() uuid.UUID {
+// RequestID is the id of this request.
+func (e *EdgeRequestContext) RequestID() string {
 	return e.raw.RequestID
 }

--- a/lib/go/internal/reddit/edgecontext/edgecontext.go
+++ b/lib/go/internal/reddit/edgecontext/edgecontext.go
@@ -618,6 +618,114 @@ func (p *Geolocation) String() string {
   return fmt.Sprintf("Geolocation(%+v)", *p)
 }
 
+// Unique identifier of this Edge Request
+// 
+// This model is a component of the "Edge-Request" header.  You should not need to
+// interact with this model directly, but rather through the EdgeRequestContext
+// interface provided by baseplate.
+// 
+// 
+// Attributes:
+//  - ReadableID: The id of this Edge Request, in the most human-readable format.
+type RequestId struct {
+  ReadableID string `thrift:"readable_id,1" db:"readable_id" json:"readable_id"`
+}
+
+func NewRequestId() *RequestId {
+  return &RequestId{}
+}
+
+
+func (p *RequestId) GetReadableID() string {
+  return p.ReadableID
+}
+func (p *RequestId) Read(ctx context.Context, iprot thrift.TProtocol) error {
+  if _, err := iprot.ReadStructBegin(ctx); err != nil {
+    return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+  }
+
+
+  for {
+    _, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+    if err != nil {
+      return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+    }
+    if fieldTypeId == thrift.STOP { break; }
+    switch fieldId {
+    case 1:
+      if fieldTypeId == thrift.STRING {
+        if err := p.ReadField1(ctx, iprot); err != nil {
+          return err
+        }
+      } else {
+        if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+          return err
+        }
+      }
+    default:
+      if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+        return err
+      }
+    }
+    if err := iprot.ReadFieldEnd(ctx); err != nil {
+      return err
+    }
+  }
+  if err := iprot.ReadStructEnd(ctx); err != nil {
+    return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+  }
+  return nil
+}
+
+func (p *RequestId)  ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+  if v, err := iprot.ReadString(ctx); err != nil {
+  return thrift.PrependError("error reading field 1: ", err)
+} else {
+  p.ReadableID = v
+}
+  return nil
+}
+
+func (p *RequestId) Write(ctx context.Context, oprot thrift.TProtocol) error {
+  if err := oprot.WriteStructBegin(ctx, "RequestId"); err != nil {
+    return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err) }
+  if p != nil {
+    if err := p.writeField1(ctx, oprot); err != nil { return err }
+  }
+  if err := oprot.WriteFieldStop(ctx); err != nil {
+    return thrift.PrependError("write field stop error: ", err) }
+  if err := oprot.WriteStructEnd(ctx); err != nil {
+    return thrift.PrependError("write struct stop error: ", err) }
+  return nil
+}
+
+func (p *RequestId) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+  if err := oprot.WriteFieldBegin(ctx, "readable_id", thrift.STRING, 1); err != nil {
+    return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:readable_id: ", p), err) }
+  if err := oprot.WriteString(ctx, string(p.ReadableID)); err != nil {
+  return thrift.PrependError(fmt.Sprintf("%T.readable_id (1) field write error: ", p), err) }
+  if err := oprot.WriteFieldEnd(ctx); err != nil {
+    return thrift.PrependError(fmt.Sprintf("%T write field end error 1:readable_id: ", p), err) }
+  return err
+}
+
+func (p *RequestId) Equals(other *RequestId) bool {
+  if p == other {
+    return true
+  } else if p == nil || other == nil {
+    return false
+  }
+  if p.ReadableID != other.ReadableID { return false }
+  return true
+}
+
+func (p *RequestId) String() string {
+  if p == nil {
+    return "<nil>"
+  }
+  return fmt.Sprintf("RequestId(%+v)", *p)
+}
+
 // Container model for the Edge-Request context header.
 // 
 // Baseplate will automatically parse this from the "Edge-Request" header and
@@ -633,6 +741,7 @@ func (p *Geolocation) String() string {
 //  - Device
 //  - OriginService
 //  - Geolocation
+//  - RequestID
 type Request struct {
   Loid *Loid `thrift:"loid,1" db:"loid" json:"loid"`
   Session *Session `thrift:"session,2" db:"session" json:"session"`
@@ -640,6 +749,7 @@ type Request struct {
   Device *Device `thrift:"device,4" db:"device" json:"device"`
   OriginService *OriginService `thrift:"origin_service,5" db:"origin_service" json:"origin_service"`
   Geolocation *Geolocation `thrift:"geolocation,6" db:"geolocation" json:"geolocation"`
+  RequestID *RequestId `thrift:"request_id,7" db:"request_id" json:"request_id,omitempty"`
 }
 
 func NewRequest() *Request {
@@ -685,6 +795,13 @@ func (p *Request) GetGeolocation() *Geolocation {
   }
 return p.Geolocation
 }
+var Request_RequestID_DEFAULT *RequestId
+func (p *Request) GetRequestID() *RequestId {
+  if !p.IsSetRequestID() {
+    return Request_RequestID_DEFAULT
+  }
+return p.RequestID
+}
 func (p *Request) IsSetLoid() bool {
   return p.Loid != nil
 }
@@ -703,6 +820,10 @@ func (p *Request) IsSetOriginService() bool {
 
 func (p *Request) IsSetGeolocation() bool {
   return p.Geolocation != nil
+}
+
+func (p *Request) IsSetRequestID() bool {
+  return p.RequestID != nil
 }
 
 func (p *Request) Read(ctx context.Context, iprot thrift.TProtocol) error {
@@ -778,6 +899,16 @@ func (p *Request) Read(ctx context.Context, iprot thrift.TProtocol) error {
           return err
         }
       }
+    case 7:
+      if fieldTypeId == thrift.STRUCT {
+        if err := p.ReadField7(ctx, iprot); err != nil {
+          return err
+        }
+      } else {
+        if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+          return err
+        }
+      }
     default:
       if err := iprot.Skip(ctx, fieldTypeId); err != nil {
         return err
@@ -843,6 +974,14 @@ func (p *Request)  ReadField6(ctx context.Context, iprot thrift.TProtocol) error
   return nil
 }
 
+func (p *Request)  ReadField7(ctx context.Context, iprot thrift.TProtocol) error {
+  p.RequestID = &RequestId{}
+  if err := p.RequestID.Read(ctx, iprot); err != nil {
+    return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.RequestID), err)
+  }
+  return nil
+}
+
 func (p *Request) Write(ctx context.Context, oprot thrift.TProtocol) error {
   if err := oprot.WriteStructBegin(ctx, "Request"); err != nil {
     return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err) }
@@ -853,6 +992,7 @@ func (p *Request) Write(ctx context.Context, oprot thrift.TProtocol) error {
     if err := p.writeField4(ctx, oprot); err != nil { return err }
     if err := p.writeField5(ctx, oprot); err != nil { return err }
     if err := p.writeField6(ctx, oprot); err != nil { return err }
+    if err := p.writeField7(ctx, oprot); err != nil { return err }
   }
   if err := oprot.WriteFieldStop(ctx); err != nil {
     return thrift.PrependError("write field stop error: ", err) }
@@ -926,6 +1066,19 @@ func (p *Request) writeField6(ctx context.Context, oprot thrift.TProtocol) (err 
   return err
 }
 
+func (p *Request) writeField7(ctx context.Context, oprot thrift.TProtocol) (err error) {
+  if p.IsSetRequestID() {
+    if err := oprot.WriteFieldBegin(ctx, "request_id", thrift.STRUCT, 7); err != nil {
+      return thrift.PrependError(fmt.Sprintf("%T write field begin error 7:request_id: ", p), err) }
+    if err := p.RequestID.Write(ctx, oprot); err != nil {
+      return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.RequestID), err)
+    }
+    if err := oprot.WriteFieldEnd(ctx); err != nil {
+      return thrift.PrependError(fmt.Sprintf("%T write field end error 7:request_id: ", p), err) }
+  }
+  return err
+}
+
 func (p *Request) Equals(other *Request) bool {
   if p == other {
     return true
@@ -938,6 +1091,7 @@ func (p *Request) Equals(other *Request) bool {
   if !p.Device.Equals(other.Device) { return false }
   if !p.OriginService.Equals(other.OriginService) { return false }
   if !p.Geolocation.Equals(other.Geolocation) { return false }
+  if !p.RequestID.Equals(other.RequestID) { return false }
   return true
 }
 

--- a/lib/py/reddit_edgecontext/thrift/ttypes.py
+++ b/lib/py/reddit_edgecontext/thrift/ttypes.py
@@ -37,16 +37,9 @@ class Loid(object):
 
     """
 
-    __slots__ = (
-        "id",
-        "created_ms",
-    )
+    __slots__ = ("id", "created_ms")
 
-    def __init__(
-        self,
-        id=None,
-        created_ms=None,
-    ):
+    def __init__(self, id=None, created_ms=None):
         self.id = id
         self.created_ms = created_ms
 
@@ -137,10 +130,7 @@ class Session(object):
 
     __slots__ = ("id",)
 
-    def __init__(
-        self,
-        id=None,
-    ):
+    def __init__(self, id=None):
         self.id = id
 
     def read(self, iprot):
@@ -221,10 +211,7 @@ class Device(object):
 
     __slots__ = ("id",)
 
-    def __init__(
-        self,
-        id=None,
-    ):
+    def __init__(self, id=None):
         self.id = id
 
     def read(self, iprot):
@@ -306,10 +293,7 @@ class OriginService(object):
 
     __slots__ = ("name",)
 
-    def __init__(
-        self,
-        name=None,
-    ):
+    def __init__(self, name=None):
         self.name = name
 
     def read(self, iprot):
@@ -389,10 +373,7 @@ class Geolocation(object):
 
     __slots__ = ("country_code",)
 
-    def __init__(
-        self,
-        country_code=None,
-    ):
+    def __init__(self, country_code=None):
         self.country_code = country_code
 
     def read(self, iprot):
@@ -457,6 +438,87 @@ class Geolocation(object):
         return not (self == other)
 
 
+class RequestId(object):
+    """
+    Unique identifier of this Edge Request
+
+    This model is a component of the "Edge-Request" header.  You should not need to
+    interact with this model directly, but rather through the EdgeRequestContext
+    interface provided by baseplate.
+
+
+    Attributes:
+     - readable_id: The id of this Edge Request, in the most human-readable format.
+
+    """
+
+    __slots__ = ("readable_id",)
+
+    def __init__(self, readable_id=None):
+        self.readable_id = readable_id
+
+    def read(self, iprot):
+        if (
+            iprot._fast_decode is not None
+            and isinstance(iprot.trans, TTransport.CReadableTransport)
+            and self.thrift_spec is not None
+        ):
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 1:
+                if ftype == TType.STRING:
+                    self.readable_id = (
+                        iprot.readString().decode("utf-8", errors="replace")
+                        if sys.version_info[0] == 2
+                        else iprot.readString()
+                    )
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin("RequestId")
+        if self.readable_id is not None:
+            oprot.writeFieldBegin("readable_id", TType.STRING, 1)
+            oprot.writeString(
+                self.readable_id.encode("utf-8") if sys.version_info[0] == 2 else self.readable_id
+            )
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ["%s=%r" % (key, getattr(self, key)) for key in self.__slots__]
+        return "%s(%s)" % (self.__class__.__name__, ", ".join(L))
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        for attr in self.__slots__:
+            my_val = getattr(self, attr)
+            other_val = getattr(other, attr)
+            if my_val != other_val:
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not (self == other)
+
+
 class Request(object):
     """
     Container model for the Edge-Request context header.
@@ -474,6 +536,7 @@ class Request(object):
      - device
      - origin_service
      - geolocation
+     - request_id
 
     """
 
@@ -484,6 +547,7 @@ class Request(object):
         "device",
         "origin_service",
         "geolocation",
+        "request_id",
     )
 
     def __init__(
@@ -494,6 +558,7 @@ class Request(object):
         device=None,
         origin_service=None,
         geolocation=None,
+        request_id=None,
     ):
         self.loid = loid
         self.session = session
@@ -501,6 +566,7 @@ class Request(object):
         self.device = device
         self.origin_service = origin_service
         self.geolocation = geolocation
+        self.request_id = request_id
 
     def read(self, iprot):
         if (
@@ -554,6 +620,12 @@ class Request(object):
                     self.geolocation.read(iprot)
                 else:
                     iprot.skip(ftype)
+            elif fid == 7:
+                if ftype == TType.STRUCT:
+                    self.request_id = RequestId()
+                    self.request_id.read(iprot)
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -592,6 +664,10 @@ class Request(object):
             oprot.writeFieldBegin("geolocation", TType.STRUCT, 6)
             self.geolocation.write(oprot)
             oprot.writeFieldEnd()
+        if self.request_id is not None:
+            oprot.writeFieldBegin("request_id", TType.STRUCT, 7)
+            self.request_id.write(oprot)
+            oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
 
@@ -619,110 +695,29 @@ class Request(object):
 all_structs.append(Loid)
 Loid.thrift_spec = (
     None,  # 0
-    (
-        1,
-        TType.STRING,
-        "id",
-        "UTF8",
-        None,
-    ),  # 1
-    (
-        2,
-        TType.I64,
-        "created_ms",
-        None,
-        None,
-    ),  # 2
+    (1, TType.STRING, "id", "UTF8", None),  # 1
+    (2, TType.I64, "created_ms", None, None),  # 2
 )
 all_structs.append(Session)
-Session.thrift_spec = (
-    None,  # 0
-    (
-        1,
-        TType.STRING,
-        "id",
-        "UTF8",
-        None,
-    ),  # 1
-)
+Session.thrift_spec = (None, (1, TType.STRING, "id", "UTF8", None))  # 0  # 1
 all_structs.append(Device)
-Device.thrift_spec = (
-    None,  # 0
-    (
-        1,
-        TType.STRING,
-        "id",
-        "UTF8",
-        None,
-    ),  # 1
-)
+Device.thrift_spec = (None, (1, TType.STRING, "id", "UTF8", None))  # 0  # 1
 all_structs.append(OriginService)
-OriginService.thrift_spec = (
-    None,  # 0
-    (
-        1,
-        TType.STRING,
-        "name",
-        "UTF8",
-        None,
-    ),  # 1
-)
+OriginService.thrift_spec = (None, (1, TType.STRING, "name", "UTF8", None))  # 0  # 1
 all_structs.append(Geolocation)
-Geolocation.thrift_spec = (
-    None,  # 0
-    (
-        1,
-        TType.STRING,
-        "country_code",
-        "UTF8",
-        None,
-    ),  # 1
-)
+Geolocation.thrift_spec = (None, (1, TType.STRING, "country_code", "UTF8", None))  # 0  # 1
+all_structs.append(RequestId)
+RequestId.thrift_spec = (None, (1, TType.STRING, "readable_id", "UTF8", None))  # 0  # 1
 all_structs.append(Request)
 Request.thrift_spec = (
     None,  # 0
-    (
-        1,
-        TType.STRUCT,
-        "loid",
-        [Loid, None],
-        None,
-    ),  # 1
-    (
-        2,
-        TType.STRUCT,
-        "session",
-        [Session, None],
-        None,
-    ),  # 2
-    (
-        3,
-        TType.STRING,
-        "authentication_token",
-        "UTF8",
-        None,
-    ),  # 3
-    (
-        4,
-        TType.STRUCT,
-        "device",
-        [Device, None],
-        None,
-    ),  # 4
-    (
-        5,
-        TType.STRUCT,
-        "origin_service",
-        [OriginService, None],
-        None,
-    ),  # 5
-    (
-        6,
-        TType.STRUCT,
-        "geolocation",
-        [Geolocation, None],
-        None,
-    ),  # 6
+    (1, TType.STRUCT, "loid", [Loid, None], None),  # 1
+    (2, TType.STRUCT, "session", [Session, None], None),  # 2
+    (3, TType.STRING, "authentication_token", "UTF8", None),  # 3
+    (4, TType.STRUCT, "device", [Device, None], None),  # 4
+    (5, TType.STRUCT, "origin_service", [OriginService, None], None),  # 5
+    (6, TType.STRUCT, "geolocation", [Geolocation, None], None),  # 6
+    (7, TType.STRUCT, "request_id", [RequestId, None], None),  # 7
 )
 fix_spec(all_structs)
 del all_structs

--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -7,10 +7,15 @@ setup(
     long_description=open("../../README.md").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/reddit/edgecontext",
-    project_urls={"Documentation": "https://reddit-edgecontext.readthedocs.io/"},
+    project_urls={
+        "Documentation": "https://reddit-edgecontext.readthedocs.io/",
+    },
     author="reddit",
     license="BSD",
-    use_scm_version={"root": "../../", "relative_to": __file__},
+    use_scm_version={
+        "root": "../../",
+        "relative_to": __file__,
+    },
     packages=find_packages(),
     python_requires=">=3.7",
     setup_requires=["setuptools_scm"],

--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -7,15 +7,10 @@ setup(
     long_description=open("../../README.md").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/reddit/edgecontext",
-    project_urls={
-        "Documentation": "https://reddit-edgecontext.readthedocs.io/",
-    },
+    project_urls={"Documentation": "https://reddit-edgecontext.readthedocs.io/"},
     author="reddit",
     license="BSD",
-    use_scm_version={
-        "root": "../../",
-        "relative_to": __file__,
-    },
+    use_scm_version={"root": "../../", "relative_to": __file__},
     packages=find_packages(),
     python_requires=">=3.7",
     setup_requires=["setuptools_scm"],

--- a/lib/py/tests/edge_context_tests.py
+++ b/lib/py/tests/edge_context_tests.py
@@ -1,3 +1,4 @@
+import struct
 import unittest
 
 from baseplate.testing.lib.secrets import FakeSecretsStore
@@ -52,10 +53,31 @@ UNIHRjPq0YEdP4hwn2DxgZdgjm/RobXNz4DWfzRVqHR+hxMso5QQ
 """
 
 AUTH_TOKEN_VALID = b"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g"  # noqa: E501
-SERIALIZED_EDGECONTEXT_WITH_NO_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x00"  # noqa: E501
-SERIALIZED_EDGECONTEXT_WITH_VALID_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x00"  # noqa: E501
-SERIALIZED_EDGECONTEXT_WITH_EXPIRED_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoxMjYyMzA0MDAwfQ.iUD0J2blW-HGtH86s66msBXymCRCgyxAZJ6xX2_SXD-kegm-KjOlIemMWFZtsNv9DJI147cNP81_gssewvUnhIHLVvXWCTOROasXbA9Yf2GUsjxoGSB7474ziPOZquAJKo8ikERlhOOVk3r4xZIIYCuc4vGZ7NfqFxjDGKAWj5Tt4VUiWXK1AdxQck24GyNOSXs677vIJnoD8EkgWqNuuwY-iFOAPVcoHmEuzhU_yUeQnY8D-VztJkip5-YPEnuuf-dTSmPbdm9ZTOP8gjTsG0Sdvb9NdLId0nEwawRy8CfFEGQulqHgd1bqTm25U-NyXQi7zroi1GEdykZ3w9fVNQ\x00"  # noqa: E501
-SERIALIZED_EDGECONTEXT_WITH_ANON_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xc0eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhbm9ueW1vdXMiXSwic3ViIjpudWxsLCJleHAiOjI1MjQ2MDgwMDB9.gQDiVzOUh70mKKK-YBTnLHWBOEuQyRllEE1-EIMfy3x5K8PsH9FB6Oy9S5HbILjfGFNrIBeux9HyW6hBDikoZDhn5QWyPNitL1pzMNONGGrXzSfaDoDbFy4MLD03A7zjG3qWBn_wLjgzUXX6qVX6W_gWO7dMqrq0iFvEegue-xQ1HGiXfPgnTrXRRovUO3JHy1LcZsmOjltYj5VGUTWXodBM8ObKEealDxg8yskEPy0IuujNMmb9eIyuHB8Ozzpg-lr790lxP37s5HCf18vrZ-IhRmLcLCqm5WSFyq_Ld2ByblBKL9pPst1AZYZTXNRIqovTAqr6v0-xjUeJ1iho9A\x00"  # noqa: E501
+REQUEST_ID = "2adaff94-9067-4de0-a00b-79fded5cff9e"
+SERIALIZED_EDGECONTEXT_WITH_NO_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x00\x0c\00\x07\00"  # noqa: E501
+SERIALIZED_EDGECONTEXT_WITH_VALID_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x00\x00"  # noqa: E501
+SERIALIZED_EDGECONTEXT_WITH_EXPIRED_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoxMjYyMzA0MDAwfQ.iUD0J2blW-HGtH86s66msBXymCRCgyxAZJ6xX2_SXD-kegm-KjOlIemMWFZtsNv9DJI147cNP81_gssewvUnhIHLVvXWCTOROasXbA9Yf2GUsjxoGSB7474ziPOZquAJKo8ikERlhOOVk3r4xZIIYCuc4vGZ7NfqFxjDGKAWj5Tt4VUiWXK1AdxQck24GyNOSXs677vIJnoD8EkgWqNuuwY-iFOAPVcoHmEuzhU_yUeQnY8D-VztJkip5-YPEnuuf-dTSmPbdm9ZTOP8gjTsG0Sdvb9NdLId0nEwawRy8CfFEGQulqHgd1bqTm25U-NyXQi7zroi1GEdykZ3w9fVNQ\x00\x0c\00\x07\00"  # noqa: E501
+SERIALIZED_EDGECONTEXT_WITH_ANON_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xc0eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhbm9ueW1vdXMiXSwic3ViIjpudWxsLCJleHAiOjI1MjQ2MDgwMDB9.gQDiVzOUh70mKKK-YBTnLHWBOEuQyRllEE1-EIMfy3x5K8PsH9FB6Oy9S5HbILjfGFNrIBeux9HyW6hBDikoZDhn5QWyPNitL1pzMNONGGrXzSfaDoDbFy4MLD03A7zjG3qWBn_wLjgzUXX6qVX6W_gWO7dMqrq0iFvEegue-xQ1HGiXfPgnTrXRRovUO3JHy1LcZsmOjltYj5VGUTWXodBM8ObKEealDxg8yskEPy0IuujNMmb9eIyuHB8Ozzpg-lr790lxP37s5HCf18vrZ-IhRmLcLCqm5WSFyq_Ld2ByblBKL9pPst1AZYZTXNRIqovTAqr6v0-xjUeJ1iho9A\x00\x0c\00\x07\00"  # noqa: E501
+SERIALIZED_EDGECONTEXT_WITH_NO_REQUEST_ID = (
+    b"\x0c\x00\x01\x00\x0c\x00\x02\x00\x0c\x00\x04\x00\x0c\x00\x05\x00\x0c\x00\x06\x00" b"\x00"
+)
+SERIALIZED_EDGECONTEXT_WITH_READABLE_REQUEST_ID = (
+    # Empty structs for the other fields
+    b"\x0c\x00\x01\x00\x0c\x00\x02\x00\x0c\x00\x04\x00\x0c\x00\x05\x00\x0c\x00\x06\x00"
+    # request_id
+    + (
+        # struct: request id
+        b"\x0c\x00\x07"
+        # string: readable_id
+        b"\x0b\x00\x01"
+        + struct.pack(">l", len(REQUEST_ID.encode("utf-8")))
+        + REQUEST_ID.encode("utf-8")
+        # end request id
+        + b"\x00"
+    )
+    # end of EdgeContext
+    + b"\x00"
+)
 
 
 class AuthenticationTokenTests(unittest.TestCase):
@@ -121,7 +143,7 @@ class EdgeContextTests(unittest.TestCase):
                         "type": "versioned",
                         "current": AUTH_TOKEN_PUBLIC_KEY,
                     }
-                },
+                }
             }
         )
         self.factory = EdgeContextFactory(self.store)
@@ -160,8 +182,25 @@ class EdgeContextTests(unittest.TestCase):
         request_context = self.factory.new()
         self.assertEqual(
             request_context._header,
-            b"\x0c\x00\x01\x00\x0c\x00\x02\x00\x0c\x00\x04\x00\x0c\x00\x05\x00\x0c\x00\x06\x00\x00",
+            # loid
+            b"\x0c\x00" b"\x01" b"\x00"  # STRUCT  # tag number  # END STRUCT
+            # session
+            b"\x0c\x00\x02\x00"
+            # device
+            b"\x0c\x00\x04\x00"
+            # origin_service
+            b"\x0c\x00\x05\x00"
+            # geolocation
+            b"\x0c\x00\x06\x00"
+            # request_id
+            b"\x0c\x00\x07\x00"
+            # end of EdgeContext
+            b"\x00",
         )
+
+    def test_create_only_request_id(self):
+        request_context = self.factory.new(request_id=REQUEST_ID)
+        self.assertEqual(request_context._header, SERIALIZED_EDGECONTEXT_WITH_READABLE_REQUEST_ID)
 
     def test_logged_out_user(self):
         request_context = self.factory.from_upstream(SERIALIZED_EDGECONTEXT_WITH_NO_AUTH)
@@ -259,3 +298,21 @@ class EdgeContextTests(unittest.TestCase):
         self.assertEqual(request_context.user.cookie_created_ms, self.LOID_CREATED_MS)
         self.assertEqual(request_context.session.id, self.SESSION_ID)
         self.assertTrue(request_context.user.has_role("anonymous"))
+
+    def test_request_id(self):
+        request_context = self.factory.from_upstream(
+            SERIALIZED_EDGECONTEXT_WITH_READABLE_REQUEST_ID
+        )
+
+        self.assertEqual(request_context.request_id.readable_id, REQUEST_ID)
+        self.assertEqual(
+            request_context.event_fields(),
+            {
+                "cookie_created_timestamp": None,
+                "user_id": None,
+                "logged_in": False,
+                "session_id": None,
+                "oauth_client_id": None,
+                "edge_request_id": REQUEST_ID,
+            },
+        )


### PR DESCRIPTION
This adds a UUID intended to be set at the CDN layer to identify every RPC that occurs to handle to a single edge request. See also trace id, but this is not shared with the client, so it stays inside our security boundary and we can trust it.