### PR TITLE
Replace locale regex with x/text

### DIFF
--- a/edgecontext.thrift
+++ b/edgecontext.thrift
@@ -7,11 +7,10 @@ namespace java com.reddit.edgecontext
 */
 typedef string AuthenticationToken
 
-/** IETF language tag representing the preferred locale for
-the client, used for providing localized content. Consists of
-an ISO 639-1 primary language subtag and an optional
-ISO 3166-1 alpha-2 region subtag separated by an underscore.
-e.g. en, en_US
+/** Valid IETF BCP47 language tag representing the preferred locale for
+the client, used for providing localized content.
+e.g. en-US
+https://tools.ietf.org/rfc/bcp/bcp47.txt
 
 */
 typedef string LocaleCode
@@ -123,8 +122,7 @@ interface provided by baseplate.
 
 */
 struct Locale {
-    /** IETF language code representing the client locale preferences.
-    Can be either {lang} or {lang}_{region} format. e.g. en, en_US
+    /** IETF BCP47 language code representing the client locale preferences. e.g. en-US
     */
     1: LocaleCode locale_code
 }

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/reddit/baseplate.go v0.8.0
 	github.com/reddit/jwt-go/v3 v3.2.2
+	golang.org/x/text v0.3.7
 )

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20u
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181221001348-537d06c36207/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/lib/go/edgecontext/edgecontext_test.go
+++ b/lib/go/edgecontext/edgecontext_test.go
@@ -17,7 +17,7 @@ import (
 const (
 	// copied from https://github.com/reddit/edgecontext.py/blob/420e58728ee7085a2f91c5db45df233142b251f9/tests/edge_context_tests.py#L55-L58
 	headerWithNoAuth            = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x00"
-	headerWithValidAuth         = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x0b\x00\x01\x00\x00\x00\x24" + expectedRequestID + "\x00\f\x00\b\v\x00\x01\x00\x00\x00\x05en_US\x00\x00"
+	headerWithValidAuth         = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x0b\x00\x01\x00\x00\x00\x24" + expectedRequestID + "\x00\f\x00\b\v\x00\x01\x00\x00\x00\x05en-US\x00\x00"
 	headerWithExpiredAuth       = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoxMjYyMzA0MDAwfQ.iUD0J2blW-HGtH86s66msBXymCRCgyxAZJ6xX2_SXD-kegm-KjOlIemMWFZtsNv9DJI147cNP81_gssewvUnhIHLVvXWCTOROasXbA9Yf2GUsjxoGSB7474ziPOZquAJKo8ikERlhOOVk3r4xZIIYCuc4vGZ7NfqFxjDGKAWj5Tt4VUiWXK1AdxQck24GyNOSXs677vIJnoD8EkgWqNuuwY-iFOAPVcoHmEuzhU_yUeQnY8D-VztJkip5-YPEnuuf-dTSmPbdm9ZTOP8gjTsG0Sdvb9NdLId0nEwawRy8CfFEGQulqHgd1bqTm25U-NyXQi7zroi1GEdykZ3w9fVNQ\x0c\x00\x07\x00\x00"
 	headerWithAnonAuth          = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xc0eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhbm9ueW1vdXMiXSwic3ViIjpudWxsLCJleHAiOjI1MjQ2MDgwMDB9.gQDiVzOUh70mKKK-YBTnLHWBOEuQyRllEE1-EIMfy3x5K8PsH9FB6Oy9S5HbILjfGFNrIBeux9HyW6hBDikoZDhn5QWyPNitL1pzMNONGGrXzSfaDoDbFy4MLD03A7zjG3qWBn_wLjgzUXX6qVX6W_gWO7dMqrq0iFvEegue-xQ1HGiXfPgnTrXRRovUO3JHy1LcZsmOjltYj5VGUTWXodBM8ObKEealDxg8yskEPy0IuujNMmb9eIyuHB8Ozzpg-lr790lxP37s5HCf18vrZ-IhRmLcLCqm5WSFyq_Ld2ByblBKL9pPst1AZYZTXNRIqovTAqr6v0-xjUeJ1iho9A\x0c\x00\x07\x00\x00"
 	headerWithReadableRequestID = ("\x0c\x00\x01\x00\x0c\x00\x02\x00\x0c\x00\x04\x00\x0c\x00\x05\x00\x0c\x00\x06\x00" +
@@ -35,7 +35,7 @@ const (
 
 const (
 	expectedCountryCode = "OK"
-	expectedLocaleCode  = "en_US"
+	expectedLocaleCode  = "en-US"
 	expectedDeviceID    = "becc50f6-ff3d-407a-aa49-fa49531363be"
 	expectedLoID        = "t2_deadbeef"
 	expectedOrigin      = "baseplate"
@@ -255,33 +255,38 @@ func TestLocale(t *testing.T) {
 			valid:  true,
 		},
 		{
-			label:  "valid-language-valid-region",
-			locale: "es_MX",
+			label:  "valid-language-longform",
+			locale: "en-US",
 			valid:  true,
 		},
 		{
-			label:  "valid-language-invalid-region",
-			locale: "es_MEX",
-			valid:  false,
-		},
-		{
-			label:  "invalid-language-valid-region",
-			locale: "esp_MX",
-			valid:  false,
-		},
-		{
-			label:  "invalid-language-invalid-region",
-			locale: "esp_MEX",
-			valid:  false,
-		},
-		{
-			label:  "invalid-separator",
+			label:  "valid-language-region",
 			locale: "es-MX",
+			valid:  true,
+		},
+		{
+			label:  "valid-language-region-numerical",
+			locale: "es-419",
+			valid:  true,
+		},
+		{
+			label:  "valid-language-region-script",
+			locale: "zh-yue-Hant",
+			valid:  true,
+		},
+		{
+			label:  "invalid-tag-end",
+			locale: "es-MX-",
 			valid:  false,
 		},
 		{
-			label:  "invalid-capitalization",
-			locale: "ES_MX",
+			label:  "invalid-double-region",
+			locale: "de-419-DE",
+			valid:  false,
+		},
+		{
+			label:  "invalid-region-combo",
+			locale: "en-EN",
 			valid:  false,
 		},
 	} {

--- a/lib/go/internal/reddit/edgecontext/edgecontext.go
+++ b/lib/go/internal/reddit/edgecontext/edgecontext.go
@@ -23,11 +23,10 @@ type AuthenticationToken string
 
 func AuthenticationTokenPtr(v AuthenticationToken) *AuthenticationToken { return &v }
 
-//IETF language tag representing the preferred locale for
-//the client, used for providing localized content. Consists of
-//an ISO 639-1 primary language subtag and an optional
-//ISO 3166-1 alpha-2 region subtag separated by an underscore.
-//e.g. en, en_US
+//Valid IETF BCP47 language tag representing the preferred locale for
+//the client, used for providing localized content.
+//e.g. en-US
+//https://tools.ietf.org/rfc/bcp/bcp47.txt
 //
 type LocaleCode string
 
@@ -746,8 +745,7 @@ func (p *RequestId) String() string {
 // 
 // 
 // Attributes:
-//  - LocaleCode: IETF language code representing the client locale preferences.
-// Can be either {lang} or {lang}_{region} format. e.g. en, en_US
+//  - LocaleCode: IETF BCP47 language code representing the client locale preferences. e.g. en-US
 type Locale struct {
   LocaleCode LocaleCode `thrift:"locale_code,1" db:"locale_code" json:"locale_code"`
 }

--- a/lib/py/reddit_edgecontext/__init__.py
+++ b/lib/py/reddit_edgecontext/__init__.py
@@ -599,9 +599,9 @@ class EdgeContextFactory(BaseEdgeContextFactory):
         if locale_code is not None and not LOCALE_CODE_RE.match(locale_code):
             raise ValueError(
                 f"locale_code <{locale_code}> is not in a valid format, it should be in "
-                "IETF language code format – an ISO 639-1 primary language subtag and an"
-                "optional ISO 3166-1 alpha-2 region subtag separated by an underscore."
-                "e.g. en_US"
+                "IETF BCP47 language code format."
+                "e.g. en-US"
+                "https://tools.ietf.org/rfc/bcp/bcp47.txt"
             )
 
         t_request = TRequest(

--- a/lib/py/reddit_edgecontext/thrift/ttypes.py
+++ b/lib/py/reddit_edgecontext/thrift/ttypes.py
@@ -552,8 +552,7 @@ class Locale(object):
 
 
     Attributes:
-     - locale_code: IETF language code representing the client locale preferences.
-    Can be either {lang} or {lang}_{region} format. e.g. en, en_US
+     - locale_code: IETF BCP47 language code representing the client locale preferences. e.g. en-US
 
     """
 

--- a/lib/py/tests/edge_context_tests.py
+++ b/lib/py/tests/edge_context_tests.py
@@ -55,7 +55,7 @@ UNIHRjPq0YEdP4hwn2DxgZdgjm/RobXNz4DWfzRVqHR+hxMso5QQ
 AUTH_TOKEN_VALID = b"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g"  # noqa: E501
 REQUEST_ID = "2adaff94-9067-4de0-a00b-79fded5cff9e"
 SERIALIZED_EDGECONTEXT_WITH_NO_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x00\x0c\00\x07\00"  # noqa: E501
-SERIALIZED_EDGECONTEXT_WITH_VALID_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x00\x0c\x00\x08\x0b\00\x01\x00\x00\x00\x05en_US\x00\x00"  # noqa: E501
+SERIALIZED_EDGECONTEXT_WITH_VALID_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x00\x0c\x00\x08\x0b\00\x01\x00\x00\x00\x05en-US\x00\x00"  # noqa: E501
 SERIALIZED_EDGECONTEXT_WITH_EXPIRED_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoxMjYyMzA0MDAwfQ.iUD0J2blW-HGtH86s66msBXymCRCgyxAZJ6xX2_SXD-kegm-KjOlIemMWFZtsNv9DJI147cNP81_gssewvUnhIHLVvXWCTOROasXbA9Yf2GUsjxoGSB7474ziPOZquAJKo8ikERlhOOVk3r4xZIIYCuc4vGZ7NfqFxjDGKAWj5Tt4VUiWXK1AdxQck24GyNOSXs677vIJnoD8EkgWqNuuwY-iFOAPVcoHmEuzhU_yUeQnY8D-VztJkip5-YPEnuuf-dTSmPbdm9ZTOP8gjTsG0Sdvb9NdLId0nEwawRy8CfFEGQulqHgd1bqTm25U-NyXQi7zroi1GEdykZ3w9fVNQ\x00\x0c\00\x07\00"  # noqa: E501
 SERIALIZED_EDGECONTEXT_WITH_ANON_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xc0eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhbm9ueW1vdXMiXSwic3ViIjpudWxsLCJleHAiOjI1MjQ2MDgwMDB9.gQDiVzOUh70mKKK-YBTnLHWBOEuQyRllEE1-EIMfy3x5K8PsH9FB6Oy9S5HbILjfGFNrIBeux9HyW6hBDikoZDhn5QWyPNitL1pzMNONGGrXzSfaDoDbFy4MLD03A7zjG3qWBn_wLjgzUXX6qVX6W_gWO7dMqrq0iFvEegue-xQ1HGiXfPgnTrXRRovUO3JHy1LcZsmOjltYj5VGUTWXodBM8ObKEealDxg8yskEPy0IuujNMmb9eIyuHB8Ozzpg-lr790lxP37s5HCf18vrZ-IhRmLcLCqm5WSFyq_Ld2ByblBKL9pPst1AZYZTXNRIqovTAqr6v0-xjUeJ1iho9A\x00\x0c\00\x07\00"  # noqa: E501
 SERIALIZED_EDGECONTEXT_WITH_NO_REQUEST_ID = (
@@ -136,7 +136,7 @@ class EdgeContextTests(unittest.TestCase):
     DEVICE_ID = "becc50f6-ff3d-407a-aa49-fa49531363be"
     ORIGIN_NAME = "baseplate"
     COUNTRY_CODE = "OK"
-    LOCALE_CODE = "en_US"
+    LOCALE_CODE = "en-US"
 
     def setUp(self):
         self.store = FakeSecretsStore(
@@ -180,7 +180,7 @@ class EdgeContextTests(unittest.TestCase):
                 loid_created_ms=self.LOID_CREATED_MS,
                 session_id=self.SESSION_ID,
                 country_code="aa",
-                locale_code="en_US",
+                locale_code="en-US",
             )
 
     def test_create_empty_context(self):


### PR DESCRIPTION
Replace the current regex with [x/text](https://pkg.go.dev/golang.org/x/text) language tag parsing.

Reasons for this are:
1. It allows locales that would previously have been filtered out to be passed through `es-419, `
2. It catches locale codes that look well-formed but aren't known `en-EN` 
2. It transforms tags into a more predictable format for parsing downstream `es-mx -> es-MX`