### PR TITLE
Fix py CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/reddit/thrift-compiler:0.14.1 AS thrift
 FROM docker.io/library/golang:1.16.1-buster AS go
-FROM python:3.8
+FROM python:3.9
 
 COPY --from=thrift /usr/local/bin/thrift /usr/local/bin/thrift
 COPY --from=go /usr/local/go /usr/local/go

--- a/lib/py/requirements-transitive.txt
+++ b/lib/py/requirements-transitive.txt
@@ -42,8 +42,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 thrift-unofficial==0.14.1rc0
 toml==0.10.2
-typed-ast==1.4.2
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.2
 urllib3==1.26.3
 zope.event==4.5.0
 zope.interface==5.2.0

--- a/lib/py/requirements.txt
+++ b/lib/py/requirements.txt
@@ -4,7 +4,7 @@ baseplate==2.0.0a2
 black==20.8b1
 cryptography==3.3.1
 flake8==3.8.4
-mypy==0.790
+mypy==0.910
 pydocstyle==5.1.1
 pyjwt==2.0.1
 pytest==6.2.1


### PR DESCRIPTION
When running the CI with python 3.9 there's an issue ([1]):

    reorder-python-imports --py3-plus --separate-from-import --separate-relative --diff-only reddit_edgecontext/thrift/constants.py reddit_edgecontext/thrift/ttypes.py reddit_edgecontext/thrift/__init__.py reddit_edgecontext/__init__.py tests/edge_context_tests.py setup.py
    black --diff --check reddit_edgecontext/thrift/constants.py reddit_edgecontext/thrift/ttypes.py reddit_edgecontext/thrift/__init__.py reddit_edgecontext/__init__.py tests/edge_context_tests.py setup.py
    Traceback (most recent call last):
      File "/opt/hostedtoolcache/Python/3.9.10/x64/bin/black", line 5, in <module>
        from black import patched_main
      File "/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/black/__init__.py", line 52, in <module>
        from typed_ast import ast3, ast27
      File "/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/typed_ast/ast3.py", line 40, in <module>
        from typed_ast import _ast3
    ImportError: /opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/typed_ast/_ast3.cpython-39-x86_64-linux-gnu.so: undefined symbol: _PyUnicode_DecodeUnicodeEscape
    make: *** [Makefile:20: lint] Error 1

This is caused by the pinned typed-ast version being too old. But
bumping typed-ast also requires us to bump the version of mypy and
typing-extensions as well, and also there's not a version of typed-ast
that works for both python 3.7 and python 3.9.

So bump versions of mypy and typing-extensions to the same version as
baseplate.py, and unpin typed-ast to support both 3.7 and 3.9.

Also update python version to 3.9 in Dockerfile.

[1]: https://github.com/reddit/edgecontext/runs/5562917588?check_suite_focus=true