### PR TITLE
Locale unification: add UnifiedLocaleCode field to EdgeContext

### DIFF
--- a/edgecontext.thrift
+++ b/edgecontext.thrift
@@ -132,8 +132,12 @@ struct Locale {
     Can be either {lang} or {lang}_{region} format. e.g. en, en_US
     */
     1: LocaleCode locale_code;
-    /** Locale code forced to the BCP-47 format (hyphen separated e.g de-DE, pt-BR, etc.).
-    This field is introduced to be used for localization instead of locale_code.
+    /** Locale code forced to the BCP-47 format 
+    Can be either {lang} or {lang}-{region} (hyphen separated) format e.g. de-DE, pt-BR, etc.
+    
+    This field is introduced to be used for localization instead of locale_code. 
+    
+    The locale_code is saved for backward compatibility.
     */
     2: UnifiedLocaleCode unified_locale_code;
 }

--- a/edgecontext.thrift
+++ b/edgecontext.thrift
@@ -132,9 +132,8 @@ struct Locale {
     Can be either {lang} or {lang}_{region} format. e.g. en, en_US
     */
     1: LocaleCode locale_code;
-    /** Locale code forced to the BCP-47 format (e.g. de-DE, pt-BR, etc.).
+    /** Locale code forced to the BCP-47 format (hyphen separated e.g de-DE, pt-BR, etc.).
     This field is introduced to be used for localization instead of locale_code.
-    The locale_code is saved for backward compatibility.
     */
     2: UnifiedLocaleCode unified_locale_code;
 }

--- a/edgecontext.thrift
+++ b/edgecontext.thrift
@@ -16,7 +16,7 @@ e.g. en, en_US
 */
 typedef string LocaleCode
 
-/** Locale code forced to the BCP-47 format 
+/** Locale code in the BCP-47 format 
 (e.g. de-DE, pt-BR, etc.)
 
 */
@@ -133,7 +133,7 @@ struct Locale {
     Can be either {lang} or {lang}_{region} format. e.g. en, en_US
     */
     1: LocaleCode locale_code;
-    /** One of supported locale codes forced to the BCP-47 format
+    /** One of the supported locale codes in the BCP-47 format.
     (e.g. de-DE, pt-BR, etc.)
     */
     2: BCP47LocaleCode negotiated_locale_code;

--- a/edgecontext.thrift
+++ b/edgecontext.thrift
@@ -16,6 +16,11 @@ e.g. en, en_US
 */
 typedef string LocaleCode
 
+/** Locale code forced to the BCP-47 format (e.g. de-DE, pt-BR, etc.).
+
+*/
+typedef string UnifiedLocaleCode
+
 /** A two-character ISO 3166-1 country code representing the current
 geographic location of the client.
 
@@ -126,7 +131,12 @@ struct Locale {
     /** IETF language code representing the client locale preferences.
     Can be either {lang} or {lang}_{region} format. e.g. en, en_US
     */
-    1: LocaleCode locale_code
+    1: LocaleCode locale_code;
+    /** Locale code forced to the BCP-47 format (e.g. de-DE, pt-BR, etc.).
+    This field is introduced to be used for localization instead of locale_code.
+    The locale_code is saved for backward compatibility.
+    */
+    2: UnifiedLocaleCode unified_locale_code;
 }
 
 /** Container model for the Edge-Request context header.

--- a/edgecontext.thrift
+++ b/edgecontext.thrift
@@ -16,11 +16,11 @@ e.g. en, en_US
 */
 typedef string LocaleCode
 
-/** One of supported locale codes forced to the BCP-47 format 
+/** Locale code forced to the BCP-47 format 
 (e.g. de-DE, pt-BR, etc.)
 
 */
-typedef string NegotiatedLocaleCode
+typedef string BCP47LocaleCode
 
 /** A two-character ISO 3166-1 country code representing the current
 geographic location of the client.
@@ -136,7 +136,7 @@ struct Locale {
     /** One of supported locale codes forced to the BCP-47 format
     (e.g. de-DE, pt-BR, etc.)
     */
-    2: NegotiatedLocaleCode negotiated_locale_code;
+    2: BCP47LocaleCode negotiated_locale_code;
 }
 
 /** Container model for the Edge-Request context header.

--- a/edgecontext.thrift
+++ b/edgecontext.thrift
@@ -16,10 +16,11 @@ e.g. en, en_US
 */
 typedef string LocaleCode
 
-/** Locale code forced to the BCP-47 format (e.g. de-DE, pt-BR, etc.).
+/** One of supported locale codes forced to the BCP-47 format 
+(e.g. de-DE, pt-BR, etc.)
 
 */
-typedef string UnifiedLocaleCode
+typedef string NegotiatedLocaleCode
 
 /** A two-character ISO 3166-1 country code representing the current
 geographic location of the client.
@@ -132,14 +133,10 @@ struct Locale {
     Can be either {lang} or {lang}_{region} format. e.g. en, en_US
     */
     1: LocaleCode locale_code;
-    /** Locale code forced to the BCP-47 format 
-    Can be either {lang} or {lang}-{region} (hyphen separated) format e.g. de-DE, pt-BR, etc.
-    
-    This field is introduced to be used for localization instead of locale_code. 
-    
-    The locale_code is saved for backward compatibility.
+    /** One of supported locale codes forced to the BCP-47 format
+    (e.g. de-DE, pt-BR, etc.)
     */
-    2: UnifiedLocaleCode unified_locale_code;
+    2: NegotiatedLocaleCode negotiated_locale_code;
 }
 
 /** Container model for the Edge-Request context header.

--- a/lib/go/edgecontext/edgecontext.go
+++ b/lib/go/edgecontext/edgecontext.go
@@ -222,7 +222,7 @@ func New(ctx context.Context, impl *Impl, args NewArgs) (*EdgeRequestContext, er
 			}
 			request.Locale = &ecthrift.Locale{
 				LocaleCode:           ecthrift.LocaleCode(args.LocaleCode),
-				NegotiatedLocaleCode: *ecthrift.NegotiatedLocaleCodePtr(ecthrift.NegotiatedLocaleCode(args.NegotiatedLocaleCode)),
+				NegotiatedLocaleCode: *ecthrift.BCP47LocaleCodePtr(ecthrift.BCP47LocaleCode(args.NegotiatedLocaleCode)),
 			}
 		} else {
 			request.Locale = &ecthrift.Locale{

--- a/lib/go/edgecontext/edgecontext.go
+++ b/lib/go/edgecontext/edgecontext.go
@@ -41,11 +41,11 @@ const LoIDPrefix = "t2_"
 // LocaleRegex validates that locale codes are correctly formatted. They can contain
 // either a language, or a language and region specifier separated by an underscore.
 // e.g. en, en_US
-var LocaleRegex = regexp.MustCompile(`^[a-z]{2,3}(_[A-Z]{2})?$`)
+var LocaleRegex = regexp.MustCompile(`^[a-z]{2,}(_[a-zA-Z\d]{2,})*$`)
 
-// UnifiedLocaleRegex validates locale codes format.
+// NegotiatedLocaleRegex validates locale codes format.
 // The same as LocaleRegex, but language and region specifier separated by a hyphen.
-var UnifiedLocaleRegex = regexp.MustCompile(`^[a-z]{2,3}(\-[A-Z]{2})?$`)
+var NegotiatedLocaleRegex = regexp.MustCompile(`^[a-z]{2,}(\-[a-zA-Z\d]{2,})*$`)
 
 var (
 	// ErrLoIDWrongPrefix is an error could be returned by New() when passed in LoID
@@ -55,8 +55,8 @@ var (
 	// ErrInvalidLocaleCode is returned by New() when an invalid locale code is passed in.
 	ErrInvalidLocaleCode = errors.New("edgecontext: locale code should match format: en, en_US")
 
-	// ErrInvalidUnifiedLocaleCode is returned by New() when an invalid unified locale code is passed in.
-	ErrInvalidUnifiedLocaleCode = errors.New("edgecontext: unified locale code should match BCP-47 format: en, en-US")
+	// ErrInvalidNegotiatedLocaleCode is returned by New() when an invalid negotiated locale code is passed in.
+	ErrInvalidNegotiatedLocaleCode = errors.New("edgecontext: negotiated locale code should match BCP-47 format: en, en-US")
 )
 
 // An Impl is an initialized edge context implementation.
@@ -169,7 +169,7 @@ type NewArgs struct {
 
 	LocaleCode string
 
-	UnifiedLocaleCode string
+	NegotiatedLocaleCode string
 }
 
 // New creates a new EdgeRequestContext from scratch.
@@ -216,13 +216,13 @@ func New(ctx context.Context, impl *Impl, args NewArgs) (*EdgeRequestContext, er
 		if !LocaleRegex.MatchString(args.LocaleCode) {
 			return nil, ErrInvalidLocaleCode
 		}
-		if args.UnifiedLocaleCode != "" {
-			if !UnifiedLocaleRegex.MatchString(args.UnifiedLocaleCode) {
-				return nil, ErrInvalidUnifiedLocaleCode
+		if args.NegotiatedLocaleCode != "" {
+			if !NegotiatedLocaleRegex.MatchString(args.NegotiatedLocaleCode) {
+				return nil, ErrInvalidNegotiatedLocaleCode
 			}
 			request.Locale = &ecthrift.Locale{
-				LocaleCode:        ecthrift.LocaleCode(args.LocaleCode),
-				UnifiedLocaleCode: ecthrift.UnifiedLocaleCode(args.UnifiedLocaleCode),
+				LocaleCode:           ecthrift.LocaleCode(args.LocaleCode),
+				NegotiatedLocaleCode: *ecthrift.NegotiatedLocaleCodePtr(ecthrift.NegotiatedLocaleCode(args.NegotiatedLocaleCode)),
 			}
 		} else {
 			request.Locale = &ecthrift.Locale{

--- a/lib/go/edgecontext/edgecontext.go
+++ b/lib/go/edgecontext/edgecontext.go
@@ -43,6 +43,10 @@ const LoIDPrefix = "t2_"
 // e.g. en, en_US
 var LocaleRegex = regexp.MustCompile(`^[a-z]{2}(_[A-Z]{2})?$`)
 
+// UnifiedLocaleRegex validates locale codes format.
+// The same as LocaleRegex, but language and region specifier separated by a hyphen.
+var UnifiedLocaleRegex = regexp.MustCompile(`^[a-z]{2}(\-[A-Z]{2})?$`)
+
 var (
 	// ErrLoIDWrongPrefix is an error could be returned by New() when passed in LoID
 	// does not have the correct prefix.
@@ -50,6 +54,9 @@ var (
 
 	// ErrInvalidLocaleCode is returned by New() when an invalid locale code is passed in.
 	ErrInvalidLocaleCode = errors.New("edgecontext: locale code should match format: en, en_US")
+
+	// ErrInvalidUnifiedLocaleCode is returned by New() when an invalid unified locale code is passed in.
+	ErrInvalidUnifiedLocaleCode = errors.New("edgecontext: unified locale code should match BCP-47 format: en, en-US")
 )
 
 // An Impl is an initialized edge context implementation.
@@ -210,6 +217,9 @@ func New(ctx context.Context, impl *Impl, args NewArgs) (*EdgeRequestContext, er
 			return nil, ErrInvalidLocaleCode
 		}
 		if args.UnifiedLocaleCode != "" {
+			if !UnifiedLocaleRegex.MatchString(args.UnifiedLocaleCode) {
+				return nil, ErrInvalidUnifiedLocaleCode
+			}
 			request.Locale = &ecthrift.Locale{
 				LocaleCode:        ecthrift.LocaleCode(args.LocaleCode),
 				UnifiedLocaleCode: ecthrift.UnifiedLocaleCode(args.UnifiedLocaleCode),

--- a/lib/go/edgecontext/edgecontext.go
+++ b/lib/go/edgecontext/edgecontext.go
@@ -41,11 +41,11 @@ const LoIDPrefix = "t2_"
 // LocaleRegex validates that locale codes are correctly formatted. They can contain
 // either a language, or a language and region specifier separated by an underscore.
 // e.g. en, en_US
-var LocaleRegex = regexp.MustCompile(`^[a-z]{2}(_[A-Z]{2})?$`)
+var LocaleRegex = regexp.MustCompile(`^[a-z]{2,3}(_[A-Z]{2})?$`)
 
 // UnifiedLocaleRegex validates locale codes format.
 // The same as LocaleRegex, but language and region specifier separated by a hyphen.
-var UnifiedLocaleRegex = regexp.MustCompile(`^[a-z]{2}(\-[A-Z]{2})?$`)
+var UnifiedLocaleRegex = regexp.MustCompile(`^[a-z]{2,3}(\-[A-Z]{2})?$`)
 
 var (
 	// ErrLoIDWrongPrefix is an error could be returned by New() when passed in LoID

--- a/lib/go/edgecontext/edgecontext.go
+++ b/lib/go/edgecontext/edgecontext.go
@@ -161,6 +161,8 @@ type NewArgs struct {
 	RequestID string
 
 	LocaleCode string
+
+	UnifiedLocaleCode string
 }
 
 // New creates a new EdgeRequestContext from scratch.
@@ -207,8 +209,15 @@ func New(ctx context.Context, impl *Impl, args NewArgs) (*EdgeRequestContext, er
 		if !LocaleRegex.MatchString(args.LocaleCode) {
 			return nil, ErrInvalidLocaleCode
 		}
-		request.Locale = &ecthrift.Locale{
-			LocaleCode: ecthrift.LocaleCode(args.LocaleCode),
+		if args.UnifiedLocaleCode != "" {
+			request.Locale = &ecthrift.Locale{
+				LocaleCode:        ecthrift.LocaleCode(args.LocaleCode),
+				UnifiedLocaleCode: ecthrift.UnifiedLocaleCode(args.UnifiedLocaleCode),
+			}
+		} else {
+			request.Locale = &ecthrift.Locale{
+				LocaleCode: ecthrift.LocaleCode(args.LocaleCode),
+			}
 		}
 	}
 

--- a/lib/go/edgecontext/edgecontext.go
+++ b/lib/go/edgecontext/edgecontext.go
@@ -43,9 +43,9 @@ const LoIDPrefix = "t2_"
 // e.g. en, en_US
 var LocaleRegex = regexp.MustCompile(`^[a-z]{2,}(_[a-zA-Z\d]{2,})*$`)
 
-// NegotiatedLocaleRegex validates locale codes format.
+// BCP47LocaleRegex validates locale codes format.
 // The same as LocaleRegex, but language and region specifier separated by a hyphen.
-var NegotiatedLocaleRegex = regexp.MustCompile(`^[a-z]{2,}(\-[a-zA-Z\d]{2,})*$`)
+var BCP47LocaleRegex = regexp.MustCompile(`^[a-z]{2,}(\-[a-zA-Z\d]{2,})*$`)
 
 var (
 	// ErrLoIDWrongPrefix is an error could be returned by New() when passed in LoID
@@ -217,7 +217,7 @@ func New(ctx context.Context, impl *Impl, args NewArgs) (*EdgeRequestContext, er
 			return nil, ErrInvalidLocaleCode
 		}
 		if args.NegotiatedLocaleCode != "" {
-			if !NegotiatedLocaleRegex.MatchString(args.NegotiatedLocaleCode) {
+			if !BCP47LocaleRegex.MatchString(args.NegotiatedLocaleCode) {
 				return nil, ErrInvalidNegotiatedLocaleCode
 			}
 			request.Locale = &ecthrift.Locale{

--- a/lib/go/edgecontext/edgecontext_test.go
+++ b/lib/go/edgecontext/edgecontext_test.go
@@ -269,12 +269,12 @@ func TestLocale(t *testing.T) {
 		},
 		{
 			label:  "invalid-language-valid-region",
-			locale: "esp_MX",
+			locale: "espn_MX",
 			valid:  false,
 		},
 		{
 			label:  "invalid-language-invalid-region",
-			locale: "esp_MEX",
+			locale: "espn_MEX",
 			valid:  false,
 		},
 		{

--- a/lib/go/edgecontext/edgecontext_test.go
+++ b/lib/go/edgecontext/edgecontext_test.go
@@ -337,6 +337,11 @@ func TestNegotiatedLocale(t *testing.T) {
 			negotiatedLocale: "de-DE-1996",
 			valid:            true,
 		},
+		{
+			label:            "valid-number",
+			negotiatedLocale: "es-419",
+			valid:            true,
+		},
 	} {
 		t.Run(c.label, func(t *testing.T) {
 			err := edgeContextWithNegotiatedLocaleCode(c.negotiatedLocale)

--- a/lib/go/edgecontext/edgecontext_test.go
+++ b/lib/go/edgecontext/edgecontext_test.go
@@ -18,7 +18,7 @@ import (
 const (
 	// copied from https://github.com/reddit/edgecontext.py/blob/420e58728ee7085a2f91c5db45df233142b251f9/tests/edge_context_tests.py#L55-L58
 	headerWithNoAuth            = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x00"
-	headerWithValidAuth         = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x0b\x00\x01\x00\x00\x00\x24" + expectedRequestID + "\x00\f\x00\b\v\x00\x01\x00\x00\x00\x05en_US\x00\x00"
+	headerWithValidAuth         = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x0b\x00\x01\x00\x00\x00\x24" + expectedRequestID + "\x00\f\x00\b\v\x00\x01\x00\x00\x00\x05en_US\v\x00\x02\x00\x00\x00\x05en-US\x00\x00"
 	headerWithExpiredAuth       = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoxMjYyMzA0MDAwfQ.iUD0J2blW-HGtH86s66msBXymCRCgyxAZJ6xX2_SXD-kegm-KjOlIemMWFZtsNv9DJI147cNP81_gssewvUnhIHLVvXWCTOROasXbA9Yf2GUsjxoGSB7474ziPOZquAJKo8ikERlhOOVk3r4xZIIYCuc4vGZ7NfqFxjDGKAWj5Tt4VUiWXK1AdxQck24GyNOSXs677vIJnoD8EkgWqNuuwY-iFOAPVcoHmEuzhU_yUeQnY8D-VztJkip5-YPEnuuf-dTSmPbdm9ZTOP8gjTsG0Sdvb9NdLId0nEwawRy8CfFEGQulqHgd1bqTm25U-NyXQi7zroi1GEdykZ3w9fVNQ\x0c\x00\x07\x00\x00"
 	headerWithAnonAuth          = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xc0eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhbm9ueW1vdXMiXSwic3ViIjpudWxsLCJleHAiOjI1MjQ2MDgwMDB9.gQDiVzOUh70mKKK-YBTnLHWBOEuQyRllEE1-EIMfy3x5K8PsH9FB6Oy9S5HbILjfGFNrIBeux9HyW6hBDikoZDhn5QWyPNitL1pzMNONGGrXzSfaDoDbFy4MLD03A7zjG3qWBn_wLjgzUXX6qVX6W_gWO7dMqrq0iFvEegue-xQ1HGiXfPgnTrXRRovUO3JHy1LcZsmOjltYj5VGUTWXodBM8ObKEealDxg8yskEPy0IuujNMmb9eIyuHB8Ozzpg-lr790lxP37s5HCf18vrZ-IhRmLcLCqm5WSFyq_Ld2ByblBKL9pPst1AZYZTXNRIqovTAqr6v0-xjUeJ1iho9A\x0c\x00\x07\x00\x00"
 	headerWithReadableRequestID = ("\x0c\x00\x01\x00\x0c\x00\x02\x00\x0c\x00\x04\x00\x0c\x00\x05\x00\x0c\x00\x06\x00" +
@@ -35,13 +35,14 @@ const (
 )
 
 const (
-	expectedCountryCode = "OK"
-	expectedLocaleCode  = "en_US"
-	expectedDeviceID    = "becc50f6-ff3d-407a-aa49-fa49531363be"
-	expectedLoID        = "t2_deadbeef"
-	expectedOrigin      = "baseplate"
-	expectedSessionID   = "beefdead"
-	expectedRequestID   = "2adaff94-9067-4de0-a00b-79fded5cff9e"
+	expectedCountryCode       = "OK"
+	expectedLocaleCode        = "en_US"
+	expectedUnifiedLocaleCode = "en-US"
+	expectedDeviceID          = "becc50f6-ff3d-407a-aa49-fa49531363be"
+	expectedLoID              = "t2_deadbeef"
+	expectedOrigin            = "baseplate"
+	expectedSessionID         = "beefdead"
+	expectedRequestID         = "2adaff94-9067-4de0-a00b-79fded5cff9e"
 
 	emptyDeviceID = "00000000-0000-0000-0000-000000000000"
 )
@@ -234,13 +235,14 @@ func TestNew(t *testing.T) {
 			OriginServiceName: expectedOrigin,
 			RequestID:         expectedRequestID,
 			LocaleCode:        expectedLocaleCode,
+			UnifiedLocaleCode: expectedUnifiedLocaleCode,
 		},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if e.Header() != headerWithValidAuth {
-		t.Errorf("Header expected %q, got %q", headerWithValidAuth, e.Header())
+		t.Errorf("Header expected \n%q\n, got \n%q", headerWithValidAuth, e.Header())
 	}
 }
 

--- a/lib/go/edgecontext/req_context.go
+++ b/lib/go/edgecontext/req_context.go
@@ -96,9 +96,9 @@ func (e *EdgeRequestContext) LocaleCode() string {
 	return e.raw.LocaleCode
 }
 
-// UnifiedLocaleCode returns the language code forced to BCP-47 standard
-func (e *EdgeRequestContext) UnifiedLocaleCode() string {
-	return e.raw.UnifiedLocaleCode
+// NegotiatedLocaleCode returns the language code forced to BCP-47 standard
+func (e *EdgeRequestContext) NegotiatedLocaleCode() string {
+	return e.raw.NegotiatedLocaleCode
 }
 
 // OriginService returns the info about the origin of this request.

--- a/lib/go/edgecontext/req_context.go
+++ b/lib/go/edgecontext/req_context.go
@@ -96,6 +96,11 @@ func (e *EdgeRequestContext) LocaleCode() string {
 	return e.raw.LocaleCode
 }
 
+// UnifiedLocaleCode returns the language code forced to BCP-47 standard
+func (e *EdgeRequestContext) UnifiedLocaleCode() string {
+	return e.raw.UnifiedLocaleCode
+}
+
 // OriginService returns the info about the origin of this request.
 func (e *EdgeRequestContext) OriginService() OriginService {
 	return OriginService{

--- a/lib/go/internal/reddit/edgecontext/edgecontext.go
+++ b/lib/go/internal/reddit/edgecontext/edgecontext.go
@@ -33,7 +33,7 @@ type LocaleCode string
 
 func LocaleCodePtr(v LocaleCode) *LocaleCode { return &v }
 
-//Locale code forced to the BCP-47 format
+//Locale code in the BCP-47 format
 //(e.g. de-DE, pt-BR, etc.)
 //
 type BCP47LocaleCode string
@@ -755,7 +755,7 @@ func (p *RequestId) String() string {
 // Attributes:
 //  - LocaleCode: IETF language code representing the client locale preferences.
 // Can be either {lang} or {lang}_{region} format. e.g. en, en_US
-//  - NegotiatedLocaleCode: One of supported locale codes forced to the BCP-47 format
+//  - NegotiatedLocaleCode: One of the supported locale codes in the BCP-47 format.
 // (e.g. de-DE, pt-BR, etc.)
 type Locale struct {
   LocaleCode LocaleCode `thrift:"locale_code,1" db:"locale_code" json:"locale_code"`

--- a/lib/go/internal/reddit/edgecontext/edgecontext.go
+++ b/lib/go/internal/reddit/edgecontext/edgecontext.go
@@ -754,9 +754,8 @@ func (p *RequestId) String() string {
 // Attributes:
 //  - LocaleCode: IETF language code representing the client locale preferences.
 // Can be either {lang} or {lang}_{region} format. e.g. en, en_US
-//  - UnifiedLocaleCode: Locale code forced to the BCP-47 format (e.g. de-DE, pt-BR, etc.).
+//  - UnifiedLocaleCode: Locale code forced to the BCP-47 format (hyphen separated e.g de-DE, pt-BR, etc.).
 // This field is introduced to be used for localization instead of locale_code.
-// The locale_code is saved for backward compatibility.
 type Locale struct {
   LocaleCode LocaleCode `thrift:"locale_code,1" db:"locale_code" json:"locale_code"`
   UnifiedLocaleCode UnifiedLocaleCode `thrift:"unified_locale_code,2" db:"unified_locale_code" json:"unified_locale_code"`

--- a/lib/go/internal/reddit/edgecontext/edgecontext.go
+++ b/lib/go/internal/reddit/edgecontext/edgecontext.go
@@ -33,11 +33,12 @@ type LocaleCode string
 
 func LocaleCodePtr(v LocaleCode) *LocaleCode { return &v }
 
-//Locale code forced to the BCP-47 format (e.g. de-DE, pt-BR, etc.).
+//One of supported locale codes forced to the BCP-47 format
+//(e.g. de-DE, pt-BR, etc.)
 //
-type UnifiedLocaleCode string
+type NegotiatedLocaleCode string
 
-func UnifiedLocaleCodePtr(v UnifiedLocaleCode) *UnifiedLocaleCode { return &v }
+func NegotiatedLocaleCodePtr(v NegotiatedLocaleCode) *NegotiatedLocaleCode { return &v }
 
 //A two-character ISO 3166-1 country code representing the current
 //geographic location of the client.
@@ -754,11 +755,11 @@ func (p *RequestId) String() string {
 // Attributes:
 //  - LocaleCode: IETF language code representing the client locale preferences.
 // Can be either {lang} or {lang}_{region} format. e.g. en, en_US
-//  - UnifiedLocaleCode: Locale code forced to the BCP-47 format (hyphen separated e.g de-DE, pt-BR, etc.).
-// This field is introduced to be used for localization instead of locale_code.
+//  - NegotiatedLocaleCode: One of supported locale codes forced to the BCP-47 format
+// (e.g. de-DE, pt-BR, etc.)
 type Locale struct {
   LocaleCode LocaleCode `thrift:"locale_code,1" db:"locale_code" json:"locale_code"`
-  UnifiedLocaleCode UnifiedLocaleCode `thrift:"unified_locale_code,2" db:"unified_locale_code" json:"unified_locale_code"`
+  NegotiatedLocaleCode NegotiatedLocaleCode `thrift:"negotiated_locale_code,2" db:"negotiated_locale_code" json:"negotiated_locale_code"`
 }
 
 func NewLocale() *Locale {
@@ -770,8 +771,8 @@ func (p *Locale) GetLocaleCode() LocaleCode {
   return p.LocaleCode
 }
 
-func (p *Locale) GetUnifiedLocaleCode() UnifiedLocaleCode {
-  return p.UnifiedLocaleCode
+func (p *Locale) GetNegotiatedLocaleCode() NegotiatedLocaleCode {
+  return p.NegotiatedLocaleCode
 }
 func (p *Locale) Read(ctx context.Context, iprot thrift.TProtocol) error {
   if _, err := iprot.ReadStructBegin(ctx); err != nil {
@@ -835,8 +836,8 @@ func (p *Locale)  ReadField2(ctx context.Context, iprot thrift.TProtocol) error 
   if v, err := iprot.ReadString(ctx); err != nil {
   return thrift.PrependError("error reading field 2: ", err)
 } else {
-  temp := UnifiedLocaleCode(v)
-  p.UnifiedLocaleCode = temp
+  temp := NegotiatedLocaleCode(v)
+  p.NegotiatedLocaleCode = temp
 }
   return nil
 }
@@ -866,12 +867,12 @@ func (p *Locale) writeField1(ctx context.Context, oprot thrift.TProtocol) (err e
 }
 
 func (p *Locale) writeField2(ctx context.Context, oprot thrift.TProtocol) (err error) {
-  if err := oprot.WriteFieldBegin(ctx, "unified_locale_code", thrift.STRING, 2); err != nil {
-    return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:unified_locale_code: ", p), err) }
-  if err := oprot.WriteString(ctx, string(p.UnifiedLocaleCode)); err != nil {
-  return thrift.PrependError(fmt.Sprintf("%T.unified_locale_code (2) field write error: ", p), err) }
+  if err := oprot.WriteFieldBegin(ctx, "negotiated_locale_code", thrift.STRING, 2); err != nil {
+    return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:negotiated_locale_code: ", p), err) }
+  if err := oprot.WriteString(ctx, string(p.NegotiatedLocaleCode)); err != nil {
+  return thrift.PrependError(fmt.Sprintf("%T.negotiated_locale_code (2) field write error: ", p), err) }
   if err := oprot.WriteFieldEnd(ctx); err != nil {
-    return thrift.PrependError(fmt.Sprintf("%T write field end error 2:unified_locale_code: ", p), err) }
+    return thrift.PrependError(fmt.Sprintf("%T write field end error 2:negotiated_locale_code: ", p), err) }
   return err
 }
 
@@ -882,7 +883,7 @@ func (p *Locale) Equals(other *Locale) bool {
     return false
   }
   if p.LocaleCode != other.LocaleCode { return false }
-  if p.UnifiedLocaleCode != other.UnifiedLocaleCode { return false }
+  if p.NegotiatedLocaleCode != other.NegotiatedLocaleCode { return false }
   return true
 }
 

--- a/lib/go/internal/reddit/edgecontext/edgecontext.go
+++ b/lib/go/internal/reddit/edgecontext/edgecontext.go
@@ -33,12 +33,12 @@ type LocaleCode string
 
 func LocaleCodePtr(v LocaleCode) *LocaleCode { return &v }
 
-//One of supported locale codes forced to the BCP-47 format
+//Locale code forced to the BCP-47 format
 //(e.g. de-DE, pt-BR, etc.)
 //
-type NegotiatedLocaleCode string
+type BCP47LocaleCode string
 
-func NegotiatedLocaleCodePtr(v NegotiatedLocaleCode) *NegotiatedLocaleCode { return &v }
+func BCP47LocaleCodePtr(v BCP47LocaleCode) *BCP47LocaleCode { return &v }
 
 //A two-character ISO 3166-1 country code representing the current
 //geographic location of the client.
@@ -759,7 +759,7 @@ func (p *RequestId) String() string {
 // (e.g. de-DE, pt-BR, etc.)
 type Locale struct {
   LocaleCode LocaleCode `thrift:"locale_code,1" db:"locale_code" json:"locale_code"`
-  NegotiatedLocaleCode NegotiatedLocaleCode `thrift:"negotiated_locale_code,2" db:"negotiated_locale_code" json:"negotiated_locale_code"`
+  NegotiatedLocaleCode BCP47LocaleCode `thrift:"negotiated_locale_code,2" db:"negotiated_locale_code" json:"negotiated_locale_code"`
 }
 
 func NewLocale() *Locale {
@@ -771,7 +771,7 @@ func (p *Locale) GetLocaleCode() LocaleCode {
   return p.LocaleCode
 }
 
-func (p *Locale) GetNegotiatedLocaleCode() NegotiatedLocaleCode {
+func (p *Locale) GetNegotiatedLocaleCode() BCP47LocaleCode {
   return p.NegotiatedLocaleCode
 }
 func (p *Locale) Read(ctx context.Context, iprot thrift.TProtocol) error {
@@ -836,7 +836,7 @@ func (p *Locale)  ReadField2(ctx context.Context, iprot thrift.TProtocol) error 
   if v, err := iprot.ReadString(ctx); err != nil {
   return thrift.PrependError("error reading field 2: ", err)
 } else {
-  temp := NegotiatedLocaleCode(v)
+  temp := BCP47LocaleCode(v)
   p.NegotiatedLocaleCode = temp
 }
   return nil

--- a/lib/py/reddit_edgecontext/__init__.py
+++ b/lib/py/reddit_edgecontext/__init__.py
@@ -34,8 +34,8 @@ logger = logging.getLogger(__name__)
 
 
 COUNTRY_CODE_RE = re.compile(r"^[A-Z]{2}$")
-LOCALE_CODE_RE = re.compile(r"^[a-z]{2}(_[A-Z]{2})?$")
-UNIFIED_LOCALE_CODE_RE = re.compile(r"^[a-z]{2}(\-[A-Z]{2})?$")
+LOCALE_CODE_RE = re.compile(r"^[a-z]{2,3}(_[A-Z]{2})?$")
+UNIFIED_LOCALE_CODE_RE = re.compile(r"^[a-z]{2,3}(\-[A-Z]{2})?$")
 
 
 class NoAuthenticationError(Exception):

--- a/lib/py/reddit_edgecontext/__init__.py
+++ b/lib/py/reddit_edgecontext/__init__.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 
 COUNTRY_CODE_RE = re.compile(r"^[A-Z]{2}$")
 LOCALE_CODE_RE = re.compile(r"^[a-z]{2}(_[A-Z]{2})?$")
+UNIFIED_LOCALE_CODE_RE = re.compile(r"^[a-z]{2}(\-[A-Z]{2})?$")
 
 
 class NoAuthenticationError(Exception):
@@ -485,7 +486,7 @@ class EdgeContext:
         """:py:class:`~reddit_edgecontext.Locale` object for the current context."""
         return Locale(
             locale_code=self._t_request.locale.locale_code,
-            unified_locale_code=self._t_request.locale.unified_locale_code
+            unified_locale_code=self._t_request.locale.unified_locale_code,
         )
 
     @cached_property
@@ -608,6 +609,14 @@ class EdgeContextFactory(BaseEdgeContextFactory):
                 "IETF language code format – an ISO 639-1 primary language subtag and an"
                 "optional ISO 3166-1 alpha-2 region subtag separated by an underscore."
                 "e.g. en_US"
+            )
+
+        if unified_locale_code is not None and not UNIFIED_LOCALE_CODE_RE.match(
+            unified_locale_code
+        ):
+            raise ValueError(
+                f"unified_locale_code <{unified_locale_code}> is not in a valid format, it should be in BCP-47."
+                f"e.g. en-US"
             )
 
         t_request = TRequest(

--- a/lib/py/reddit_edgecontext/__init__.py
+++ b/lib/py/reddit_edgecontext/__init__.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 COUNTRY_CODE_RE = re.compile(r"^[A-Z]{2}$")
 LOCALE_CODE_RE = re.compile(r"^[a-z]{2,}(_[a-zA-Z\d]{2,})*$")
-NEGOTIATED_LOCALE_CODE_RE = re.compile(r"^[a-z]{2,}(\-[a-zA-Z\d]{2,})*$")
+BCP47_LOCALE_CODE_RE = re.compile(r"^[a-z]{2,}(\-[a-zA-Z\d]{2,})*$")
 
 
 class NoAuthenticationError(Exception):
@@ -611,7 +611,7 @@ class EdgeContextFactory(BaseEdgeContextFactory):
                 "e.g. en_US"
             )
 
-        if negotiated_locale_code is not None and not NEGOTIATED_LOCALE_CODE_RE.match(
+        if negotiated_locale_code is not None and not BCP47_LOCALE_CODE_RE.match(
             negotiated_locale_code
         ):
             raise ValueError(

--- a/lib/py/reddit_edgecontext/__init__.py
+++ b/lib/py/reddit_edgecontext/__init__.py
@@ -226,6 +226,9 @@ class Locale(NamedTuple):
     locale_code: str
     """IETF language tag representing the preferred locale for the client."""
 
+    unified_locale_code: str
+    """ Locale code forced to BCP-47 standard """
+
 
 class User(NamedTuple):
     """Wrapper for the user values in AuthenticationToken and the LoId cookie."""
@@ -482,6 +485,7 @@ class EdgeContext:
         """:py:class:`~reddit_edgecontext.Locale` object for the current context."""
         return Locale(
             locale_code=self._t_request.locale.locale_code,
+            unified_locale_code=self._t_request.locale.unified_locale_code
         )
 
     @cached_property
@@ -538,6 +542,7 @@ class EdgeContextFactory(BaseEdgeContextFactory):
         country_code: Optional[str] = None,
         request_id: Optional[str] = None,
         locale_code: Optional[str] = None,
+        unified_locale_code: Optional[str] = None,
     ) -> EdgeContext:
         """Return a new EdgeContext object made from scratch.
 
@@ -582,6 +587,7 @@ class EdgeContextFactory(BaseEdgeContextFactory):
             the underlying request that this EdgeContext represents.
         :param locale_code: IETF language tag representing the preferred locale
             for the client.
+        :param unified_locale_code: locale code forced to BCP-47 standard
 
         """
         if loid_id is not None and not loid_id.startswith("t2_"):
@@ -612,7 +618,7 @@ class EdgeContextFactory(BaseEdgeContextFactory):
             origin_service=TOriginService(name=origin_service_name),
             geolocation=TGeolocation(country_code=country_code),
             request_id=TRequestId(readable_id=request_id),
-            locale=TLocale(locale_code=locale_code),
+            locale=TLocale(locale_code=locale_code, unified_locale_code=unified_locale_code),
         )
         header = TSerialization.serialize(t_request, EdgeContext._HEADER_PROTOCOL_FACTORY)
 

--- a/lib/py/reddit_edgecontext/thrift/ttypes.py
+++ b/lib/py/reddit_edgecontext/thrift/ttypes.py
@@ -554,7 +554,7 @@ class Locale(object):
     Attributes:
      - locale_code: IETF language code representing the client locale preferences.
     Can be either {lang} or {lang}_{region} format. e.g. en, en_US
-     - negotiated_locale_code: One of supported locale codes forced to the BCP-47 format
+     - negotiated_locale_code: One of the supported locale codes in the BCP-47 format.
     (e.g. de-DE, pt-BR, etc.)
 
     """

--- a/lib/py/reddit_edgecontext/thrift/ttypes.py
+++ b/lib/py/reddit_edgecontext/thrift/ttypes.py
@@ -554,16 +554,24 @@ class Locale(object):
     Attributes:
      - locale_code: IETF language code representing the client locale preferences.
     Can be either {lang} or {lang}_{region} format. e.g. en, en_US
+     - unified_locale_code: Locale code forced to the BCP-47 format (e.g. de-DE, pt-BR, etc.).
+    This field is introduced to be used for localization instead of locale_code.
+    The locale_code is saved for backward compatibility.
 
     """
 
-    __slots__ = ("locale_code",)
+    __slots__ = (
+        "locale_code",
+        "unified_locale_code",
+    )
 
     def __init__(
         self,
         locale_code=None,
+        unified_locale_code=None,
     ):
         self.locale_code = locale_code
+        self.unified_locale_code = unified_locale_code
 
     def read(self, iprot):
         if (
@@ -587,6 +595,15 @@ class Locale(object):
                     )
                 else:
                     iprot.skip(ftype)
+            elif fid == 2:
+                if ftype == TType.STRING:
+                    self.unified_locale_code = (
+                        iprot.readString().decode("utf-8", errors="replace")
+                        if sys.version_info[0] == 2
+                        else iprot.readString()
+                    )
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -601,6 +618,14 @@ class Locale(object):
             oprot.writeFieldBegin("locale_code", TType.STRING, 1)
             oprot.writeString(
                 self.locale_code.encode("utf-8") if sys.version_info[0] == 2 else self.locale_code
+            )
+            oprot.writeFieldEnd()
+        if self.unified_locale_code is not None:
+            oprot.writeFieldBegin("unified_locale_code", TType.STRING, 2)
+            oprot.writeString(
+                self.unified_locale_code.encode("utf-8")
+                if sys.version_info[0] == 2
+                else self.unified_locale_code
             )
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -897,6 +922,13 @@ Locale.thrift_spec = (
         "UTF8",
         None,
     ),  # 1
+    (
+        2,
+        TType.STRING,
+        "unified_locale_code",
+        "UTF8",
+        None,
+    ),  # 2
 )
 all_structs.append(Request)
 Request.thrift_spec = (

--- a/lib/py/reddit_edgecontext/thrift/ttypes.py
+++ b/lib/py/reddit_edgecontext/thrift/ttypes.py
@@ -554,23 +554,23 @@ class Locale(object):
     Attributes:
      - locale_code: IETF language code representing the client locale preferences.
     Can be either {lang} or {lang}_{region} format. e.g. en, en_US
-     - unified_locale_code: Locale code forced to the BCP-47 format (hyphen separated e.g de-DE, pt-BR, etc.).
-    This field is introduced to be used for localization instead of locale_code.
+     - negotiated_locale_code: One of supported locale codes forced to the BCP-47 format
+    (e.g. de-DE, pt-BR, etc.)
 
     """
 
     __slots__ = (
         "locale_code",
-        "unified_locale_code",
+        "negotiated_locale_code",
     )
 
     def __init__(
         self,
         locale_code=None,
-        unified_locale_code=None,
+        negotiated_locale_code=None,
     ):
         self.locale_code = locale_code
-        self.unified_locale_code = unified_locale_code
+        self.negotiated_locale_code = negotiated_locale_code
 
     def read(self, iprot):
         if (
@@ -596,7 +596,7 @@ class Locale(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.unified_locale_code = (
+                    self.negotiated_locale_code = (
                         iprot.readString().decode("utf-8", errors="replace")
                         if sys.version_info[0] == 2
                         else iprot.readString()
@@ -619,12 +619,12 @@ class Locale(object):
                 self.locale_code.encode("utf-8") if sys.version_info[0] == 2 else self.locale_code
             )
             oprot.writeFieldEnd()
-        if self.unified_locale_code is not None:
-            oprot.writeFieldBegin("unified_locale_code", TType.STRING, 2)
+        if self.negotiated_locale_code is not None:
+            oprot.writeFieldBegin("negotiated_locale_code", TType.STRING, 2)
             oprot.writeString(
-                self.unified_locale_code.encode("utf-8")
+                self.negotiated_locale_code.encode("utf-8")
                 if sys.version_info[0] == 2
-                else self.unified_locale_code
+                else self.negotiated_locale_code
             )
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -924,7 +924,7 @@ Locale.thrift_spec = (
     (
         2,
         TType.STRING,
-        "unified_locale_code",
+        "negotiated_locale_code",
         "UTF8",
         None,
     ),  # 2

--- a/lib/py/reddit_edgecontext/thrift/ttypes.py
+++ b/lib/py/reddit_edgecontext/thrift/ttypes.py
@@ -554,9 +554,8 @@ class Locale(object):
     Attributes:
      - locale_code: IETF language code representing the client locale preferences.
     Can be either {lang} or {lang}_{region} format. e.g. en, en_US
-     - unified_locale_code: Locale code forced to the BCP-47 format (e.g. de-DE, pt-BR, etc.).
+     - unified_locale_code: Locale code forced to the BCP-47 format (hyphen separated e.g de-DE, pt-BR, etc.).
     This field is introduced to be used for localization instead of locale_code.
-    The locale_code is saved for backward compatibility.
 
     """
 

--- a/lib/py/tests/edge_context_tests.py
+++ b/lib/py/tests/edge_context_tests.py
@@ -137,7 +137,7 @@ class EdgeContextTests(unittest.TestCase):
     ORIGIN_NAME = "baseplate"
     COUNTRY_CODE = "OK"
     LOCALE_CODE = "en_US"
-    UNIFIED_LOCALE_CODE = "en-US"
+    NEGOTIATED_LOCALE_CODE = "en-US"
 
     def setUp(self):
         self.store = FakeSecretsStore(
@@ -162,7 +162,7 @@ class EdgeContextTests(unittest.TestCase):
             origin_service_name=self.ORIGIN_NAME,
             country_code=self.COUNTRY_CODE,
             locale_code=self.LOCALE_CODE,
-            unified_locale_code=self.UNIFIED_LOCALE_CODE,
+            negotiated_locale_code=self.NEGOTIATED_LOCALE_CODE,
         )
         self.assertIsNot(request_context._t_request, None)
         self.assertEqual(request_context._header, SERIALIZED_EDGECONTEXT_WITH_VALID_AUTH)
@@ -198,7 +198,7 @@ class EdgeContextTests(unittest.TestCase):
                 loid_id=self.LOID_ID,
                 loid_created_ms=self.LOID_CREATED_MS,
                 session_id=self.SESSION_ID,
-                unified_locale_code="en_US",
+                negotiated_locale_code="en_US",
             )
 
     def test_create_empty_context(self):
@@ -275,7 +275,7 @@ class EdgeContextTests(unittest.TestCase):
         self.assertEqual(request_context.origin_service.name, self.ORIGIN_NAME)
         self.assertEqual(request_context.geolocation.country_code, self.COUNTRY_CODE)
         self.assertEqual(request_context.locale.locale_code, self.LOCALE_CODE)
-        self.assertEqual(request_context.locale.unified_locale_code, self.UNIFIED_LOCALE_CODE)
+        self.assertEqual(request_context.locale.negotiated_locale_code, self.NEGOTIATED_LOCALE_CODE)
         self.assertEqual(
             request_context.event_fields(),
             {

--- a/lib/py/tests/edge_context_tests.py
+++ b/lib/py/tests/edge_context_tests.py
@@ -55,7 +55,7 @@ UNIHRjPq0YEdP4hwn2DxgZdgjm/RobXNz4DWfzRVqHR+hxMso5QQ
 AUTH_TOKEN_VALID = b"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g"  # noqa: E501
 REQUEST_ID = "2adaff94-9067-4de0-a00b-79fded5cff9e"
 SERIALIZED_EDGECONTEXT_WITH_NO_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x00\x0c\00\x07\00"  # noqa: E501
-SERIALIZED_EDGECONTEXT_WITH_VALID_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x00\x0c\x00\x08\x0b\00\x01\x00\x00\x00\x05en_US\x00\x00"  # noqa: E501
+SERIALIZED_EDGECONTEXT_WITH_VALID_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x0c\x00\x07\x00\x0c\x00\x08\x0b\00\x01\x00\x00\x00\x05en_US\v\x00\x02\x00\x00\x00\x05en-US\x00\x00"  # noqa: E501
 SERIALIZED_EDGECONTEXT_WITH_EXPIRED_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoxMjYyMzA0MDAwfQ.iUD0J2blW-HGtH86s66msBXymCRCgyxAZJ6xX2_SXD-kegm-KjOlIemMWFZtsNv9DJI147cNP81_gssewvUnhIHLVvXWCTOROasXbA9Yf2GUsjxoGSB7474ziPOZquAJKo8ikERlhOOVk3r4xZIIYCuc4vGZ7NfqFxjDGKAWj5Tt4VUiWXK1AdxQck24GyNOSXs677vIJnoD8EkgWqNuuwY-iFOAPVcoHmEuzhU_yUeQnY8D-VztJkip5-YPEnuuf-dTSmPbdm9ZTOP8gjTsG0Sdvb9NdLId0nEwawRy8CfFEGQulqHgd1bqTm25U-NyXQi7zroi1GEdykZ3w9fVNQ\x00\x0c\00\x07\00"  # noqa: E501
 SERIALIZED_EDGECONTEXT_WITH_ANON_AUTH = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xc0eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhbm9ueW1vdXMiXSwic3ViIjpudWxsLCJleHAiOjI1MjQ2MDgwMDB9.gQDiVzOUh70mKKK-YBTnLHWBOEuQyRllEE1-EIMfy3x5K8PsH9FB6Oy9S5HbILjfGFNrIBeux9HyW6hBDikoZDhn5QWyPNitL1pzMNONGGrXzSfaDoDbFy4MLD03A7zjG3qWBn_wLjgzUXX6qVX6W_gWO7dMqrq0iFvEegue-xQ1HGiXfPgnTrXRRovUO3JHy1LcZsmOjltYj5VGUTWXodBM8ObKEealDxg8yskEPy0IuujNMmb9eIyuHB8Ozzpg-lr790lxP37s5HCf18vrZ-IhRmLcLCqm5WSFyq_Ld2ByblBKL9pPst1AZYZTXNRIqovTAqr6v0-xjUeJ1iho9A\x00\x0c\00\x07\00"  # noqa: E501
 SERIALIZED_EDGECONTEXT_WITH_NO_REQUEST_ID = (
@@ -137,6 +137,7 @@ class EdgeContextTests(unittest.TestCase):
     ORIGIN_NAME = "baseplate"
     COUNTRY_CODE = "OK"
     LOCALE_CODE = "en_US"
+    UNIFIED_LOCALE_CODE = "en-US"
 
     def setUp(self):
         self.store = FakeSecretsStore(
@@ -161,6 +162,7 @@ class EdgeContextTests(unittest.TestCase):
             origin_service_name=self.ORIGIN_NAME,
             country_code=self.COUNTRY_CODE,
             locale_code=self.LOCALE_CODE,
+            unified_locale_code=self.UNIFIED_LOCALE_CODE,
         )
         self.assertIsNot(request_context._t_request, None)
         self.assertEqual(request_context._header, SERIALIZED_EDGECONTEXT_WITH_VALID_AUTH)
@@ -181,6 +183,22 @@ class EdgeContextTests(unittest.TestCase):
                 session_id=self.SESSION_ID,
                 country_code="aa",
                 locale_code="en_US",
+            )
+        with self.assertRaises(ValueError):
+            self.factory.new(
+                authentication_token=AUTH_TOKEN_VALID,
+                loid_id=self.LOID_ID,
+                loid_created_ms=self.LOID_CREATED_MS,
+                session_id=self.SESSION_ID,
+                locale_code="enUS",
+            )
+        with self.assertRaises(ValueError):
+            self.factory.new(
+                authentication_token=AUTH_TOKEN_VALID,
+                loid_id=self.LOID_ID,
+                loid_created_ms=self.LOID_CREATED_MS,
+                session_id=self.SESSION_ID,
+                unified_locale_code="en_US",
             )
 
     def test_create_empty_context(self):
@@ -257,6 +275,7 @@ class EdgeContextTests(unittest.TestCase):
         self.assertEqual(request_context.origin_service.name, self.ORIGIN_NAME)
         self.assertEqual(request_context.geolocation.country_code, self.COUNTRY_CODE)
         self.assertEqual(request_context.locale.locale_code, self.LOCALE_CODE)
+        self.assertEqual(request_context.locale.unified_locale_code, self.UNIFIED_LOCALE_CODE)
         self.assertEqual(
             request_context.event_fields(),
             {


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
This PR introduces a new `NegotiatedLocaleCode` field in the `Locale` struct. This field should be filled with one of the supported locale value in the BCP-47 format (language and region separated by a hyphen). It is going to be used for localization and communications across different Reddit services as one unified locale value.

## 📜 Details
[Design Doc](https://docs.google.com/document/d/13_u9iK5Myj217YW9sjvxmUopM73S_clEEebZjNolr4k/edit#heading=h.4aw81zss826e)

[Jira epic](https://reddit.atlassian.net/browse/IPLAT-275), [Ticket](https://reddit.atlassian.net/browse/IPLAT-565)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [✅] CI tests (if present) are passing
- [✅] Adheres to code style for repo
- [?] Contributor License Agreement (CLA) completed if not a Reddit employee
