### PR TITLE
Locale Unification: update LocaleCode field validation

### DIFF
--- a/edgecontext.thrift
+++ b/edgecontext.thrift
@@ -122,9 +122,10 @@ interface provided by baseplate.
 
 */
 struct Locale {
-    /** IETF language code representing the client locale preferences.
-    Preferably in BCP-47 format ({lang} or {lang}-{region}), 
-    but underscore separated locales also valid ({lang}_{region})
+    /** IETF language tag representing the preferred locale for
+    the client, used for providing localized content. Consists of
+    an ISO 639-1 primary language subtag and an optional
+    ISO 3166-1 alpha-2 region subtag.
     */
     1: LocaleCode locale_code
 }

--- a/edgecontext.thrift
+++ b/edgecontext.thrift
@@ -10,8 +10,7 @@ typedef string AuthenticationToken
 /** IETF language tag representing the preferred locale for
 the client, used for providing localized content. Consists of
 an ISO 639-1 primary language subtag and an optional
-ISO 3166-1 alpha-2 region subtag separated by an underscore.
-e.g. en, en_US
+ISO 3166-1 alpha-2 region subtag.
 
 */
 typedef string LocaleCode
@@ -124,7 +123,8 @@ interface provided by baseplate.
 */
 struct Locale {
     /** IETF language code representing the client locale preferences.
-    Can be either {lang} or {lang}_{region} format. e.g. en, en_US
+    Preferably in BCP-47 format ({lang} or {lang}-{region}), 
+    but underscore separated locales also valid ({lang}_{region})
     */
     1: LocaleCode locale_code
 }

--- a/lib/go/edgecontext/edgecontext.go
+++ b/lib/go/edgecontext/edgecontext.go
@@ -41,7 +41,7 @@ const LoIDPrefix = "t2_"
 // LocaleRegex validates that locale codes are correctly formatted. They can contain
 // either a language, or a language and region specifier separated by an underscore.
 // e.g. en, en_US
-var LocaleRegex = regexp.MustCompile(`^[a-z]{2}(_[A-Z]{2})?$`)
+var LocaleRegex = regexp.MustCompile(`^[a-z]{2,}([_|\-][\da-zA-Z]{2,})*$`)
 
 var (
 	// ErrLoIDWrongPrefix is an error could be returned by New() when passed in LoID

--- a/lib/go/edgecontext/edgecontext_test.go
+++ b/lib/go/edgecontext/edgecontext_test.go
@@ -261,29 +261,34 @@ func TestLocale(t *testing.T) {
 			valid:  true,
 		},
 		{
-			label:  "valid-language-invalid-region",
-			locale: "es_MEX",
-			valid:  false,
-		},
-		{
-			label:  "invalid-language-valid-region",
-			locale: "esp_MX",
-			valid:  false,
-		},
-		{
-			label:  "invalid-language-invalid-region",
-			locale: "esp_MEX",
-			valid:  false,
+			label:  "valid-language-valid-region-hyphen",
+			locale: "es-MX",
+			valid:  true,
 		},
 		{
 			label:  "invalid-separator",
-			locale: "es-MX",
+			locale: "esMX",
 			valid:  false,
 		},
 		{
 			label:  "invalid-capitalization",
 			locale: "ES_MX",
 			valid:  false,
+		},
+		{
+			label:  "valid-alphabet",
+			locale: "sr-Latn",
+			valid:  true,
+		},
+		{
+			label:  "valid-orthography",
+			locale: "de-DE-1996",
+			valid:  true,
+		},
+		{
+			label:  "valid-number",
+			locale: "es-419",
+			valid:  true,
 		},
 	} {
 		t.Run(c.label, func(t *testing.T) {

--- a/lib/go/internal/reddit/edgecontext/edgecontext.go
+++ b/lib/go/internal/reddit/edgecontext/edgecontext.go
@@ -26,8 +26,7 @@ func AuthenticationTokenPtr(v AuthenticationToken) *AuthenticationToken { return
 //IETF language tag representing the preferred locale for
 //the client, used for providing localized content. Consists of
 //an ISO 639-1 primary language subtag and an optional
-//ISO 3166-1 alpha-2 region subtag separated by an underscore.
-//e.g. en, en_US
+//ISO 3166-1 alpha-2 region subtag.
 //
 type LocaleCode string
 
@@ -747,7 +746,8 @@ func (p *RequestId) String() string {
 // 
 // Attributes:
 //  - LocaleCode: IETF language code representing the client locale preferences.
-// Can be either {lang} or {lang}_{region} format. e.g. en, en_US
+// Preferably in BCP-47 format ({lang} or {lang}-{region}),
+// but underscore separated locales also valid ({lang}_{region})
 type Locale struct {
   LocaleCode LocaleCode `thrift:"locale_code,1" db:"locale_code" json:"locale_code"`
 }

--- a/lib/py/reddit_edgecontext/__init__.py
+++ b/lib/py/reddit_edgecontext/__init__.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 COUNTRY_CODE_RE = re.compile(r"^[A-Z]{2}$")
-LOCALE_CODE_RE = re.compile(r"^[a-z]{2}(_[A-Z]{2})?$")
+LOCALE_CODE_RE = re.compile(r"^[a-z]{2,}([_|\-][\da-zA-Z]{2,})*$")
 
 
 class NoAuthenticationError(Exception):

--- a/lib/py/reddit_edgecontext/thrift/ttypes.py
+++ b/lib/py/reddit_edgecontext/thrift/ttypes.py
@@ -553,7 +553,8 @@ class Locale(object):
 
     Attributes:
      - locale_code: IETF language code representing the client locale preferences.
-    Can be either {lang} or {lang}_{region} format. e.g. en, en_US
+    Preferably in BCP-47 format ({lang} or {lang}-{region}),
+    but underscore separated locales also valid ({lang}_{region})
 
     """
 


### PR DESCRIPTION

## 💸 TL;DR
This PR updates the` LocaleCode` field validation to pass locales in BCP-47 format (hyphen separated) according to the locale unification project (see design doc). Underscore-separated locales are still valid due to backward compatibility.

## 📜 Details
[Design Doc](https://docs.google.com/document/d/13_u9iK5Myj217YW9sjvxmUopM73S_clEEebZjNolr4k/edit#heading=h.4aw81zss826e)

[Jira epic](https://reddit.atlassian.net/browse/IPLAT-275), [Ticket](https://reddit.atlassian.net/browse/IPLAT-565)

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [✅] CI tests (if present) are passing
- [✅] Adheres to code style for repo
- [?] Contributor License Agreement (CLA) completed if not a Reddit employee
