### PR TITLE
go: upgrade jwt library to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/apache/thrift v0.16.0
 	github.com/gofrs/uuid v3.2.0+incompatible
-	github.com/golang-jwt/jwt/v4 v4.3.0
+	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/reddit/baseplate.go v0.9.6
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
 )

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/E
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
-github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/lib/go/edgecontext/token.go
+++ b/lib/go/edgecontext/token.go
@@ -1,13 +1,13 @@
 package edgecontext
 
 import (
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/reddit/baseplate.go/timebp"
 )
 
 // AuthenticationToken defines the json format of the authentication token.
 type AuthenticationToken struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 
 	// NOTE: Subject field is in StandardClaims.
 
@@ -25,5 +25,5 @@ type AuthenticationToken struct {
 
 // Subject returns the subject field of the token.
 func (t AuthenticationToken) Subject() string {
-	return t.StandardClaims.Subject
+	return t.RegisteredClaims.Subject
 }

--- a/lib/go/edgecontext/validator_test.go
+++ b/lib/go/edgecontext/validator_test.go
@@ -3,7 +3,7 @@ package edgecontext_test
 import (
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/reddit/edgecontext/lib/go/edgecontext"
 )

--- a/lib/go/edgecontext/validator_test.go
+++ b/lib/go/edgecontext/validator_test.go
@@ -1,6 +1,7 @@
 package edgecontext_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -20,6 +21,35 @@ func TestValidToken(t *testing.T) {
 	actual := token.Subject()
 	if actual != expected {
 		t.Errorf("subject expected %q, got %q", expected, actual)
+	}
+}
+
+func TestInvalidToken(t *testing.T) {
+	cases := []struct {
+		name  string
+		token string
+		want  error
+	}{
+		{
+			name:  "wrong algorithm",
+			token: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g`,
+			want:  jwt.ErrTokenSignatureInvalid,
+		},
+		{
+			name:  "invalid signature",
+			token: `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.foobar`,
+			want:  jwt.ErrTokenSignatureInvalid,
+		},
+	}
+
+	for _, _c := range cases {
+		c := _c
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := globalTestImpl.ValidateToken(c.token); !errors.Is(err, c.want) {
+				t.Errorf("error mismatch: want %v, got %v", c.want, err)
+
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 💸 TL;DR
Upgrade golang-jwt/jwt to v5.

## 📜 Details
[v5](https://github.com/golang-jwt/jwt/releases/tag/v5.0.0) has some breaking changes that we have to account for when upgrading.

- `jwt.StandardClaims` was deprecated in v4 and removed in v5, replaced with `jwt.RegisteredClaims`
- `jwt.NewValidationError` was removed. Replaced by new errors in the edgecontext library and additional checks in the `ParseWithClaims` call

## 🧪 Testing Steps / Validation

- Unit tests
- Add more tests to verify changes to errors

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
