### PR TITLE
Fix token validation error logging on expired tokens

### DIFF
--- a/lib/go/edgecontext/req_context.go
+++ b/lib/go/edgecontext/req_context.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/gofrs/uuid"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/reddit/baseplate.go/experiments"
 )
 
@@ -47,8 +48,9 @@ func (e *EdgeRequestContext) getCtx() context.Context {
 func (e *EdgeRequestContext) AuthToken() *AuthenticationToken {
 	e.tokenOnce.Do(func() {
 		if token, err := e.impl.ValidateToken(e.raw.AuthToken); err != nil {
-			// empty jwt token is considered "normal", no need to spam them in logs.
-			if !errors.Is(err, ErrEmptyToken) {
+			// empty jwt token is considered "normal", no need to spam them in logs. likewise, expired JWT is "normal"
+			// and not exceptional.
+			if !errors.Is(err, ErrEmptyToken) || !errors.Is(err, jwt.ErrTokenExpired) {
 				e.impl.logger.Log(e.getCtx(), "token validation failed: "+err.Error())
 			}
 			e.token = nil

--- a/lib/go/edgecontext/validator_test.go
+++ b/lib/go/edgecontext/validator_test.go
@@ -40,6 +40,11 @@ func TestInvalidToken(t *testing.T) {
 			token: `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.foobar`,
 			want:  jwt.ErrTokenSignatureInvalid,
 		},
+		{
+			name:  "expired",
+			token: `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoxMjYyMzA0MDAwfQ.iUD0J2blW-HGtH86s66msBXymCRCgyxAZJ6xX2_SXD-kegm-KjOlIemMWFZtsNv9DJI147cNP81_gssewvUnhIHLVvXWCTOROasXbA9Yf2GUsjxoGSB7474ziPOZquAJKo8ikERlhOOVk3r4xZIIYCuc4vGZ7NfqFxjDGKAWj5Tt4VUiWXK1AdxQck24GyNOSXs677vIJnoD8EkgWqNuuwY-iFOAPVcoHmEuzhU_yUeQnY8D-VztJkip5-YPEnuuf-dTSmPbdm9ZTOP8gjTsG0Sdvb9NdLId0nEwawRy8CfFEGQulqHgd1bqTm25U-NyXQi7zroi1GEdykZ3w9fVNQ`,
+			want:  jwt.ErrTokenExpired,
+		},
 	}
 
 	for _, _c := range cases {


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
Reduces log spam for expired token validation. This is a non-exceptional case and we shouldn't log an error.

## 📜 Details

## 🧪 Testing Steps / Validation
Added unit test to ensure ValidateJWT will return jwt.ErrTokenExpired. Note, we don't have a way to assert on log output.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- x ] Contributor License Agreement (CLA) completed if not a Reddit employee
