### PR TITLE
add back in 'ValidateToken' method that was accidentally removed

### DIFF
--- a/lib/go/edgecontext/edgecontext.go
+++ b/lib/go/edgecontext/edgecontext.go
@@ -101,6 +101,20 @@ func Init(cfg Config) *Impl {
 	}
 }
 
+func (i *Impl) ValidateToken(token string) (*AuthenticationToken, error) {
+	ec, err := New(context.Background(), i, NewArgs{
+		AuthToken: token,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ec.AuthToken(), nil
+}
+
+func (i *Impl) FromHeader(ctx context.Context, header string) (*EdgeRequestContext, error) {
+	return getBackend().FromHeader(ctx, header, i)
+}
+
 // NewArgs are the args for New function.
 //
 // All fields are optional.

--- a/lib/go/edgecontext/edgecontext.go
+++ b/lib/go/edgecontext/edgecontext.go
@@ -101,6 +101,8 @@ func Init(cfg Config) *Impl {
 	}
 }
 
+// ValidateToken parses and validates a jwt token, and return the decoded
+// AuthenticationToken.
 func (i *Impl) ValidateToken(token string) (*AuthenticationToken, error) {
 	ec, err := New(context.Background(), i, NewArgs{
 		AuthToken: token,
@@ -109,10 +111,6 @@ func (i *Impl) ValidateToken(token string) (*AuthenticationToken, error) {
 		return nil, err
 	}
 	return ec.AuthToken(), nil
-}
-
-func (i *Impl) FromHeader(ctx context.Context, header string) (*EdgeRequestContext, error) {
-	return getBackend().FromHeader(ctx, header, i)
 }
 
 // NewArgs are the args for New function.


### PR DESCRIPTION
## 💸 TL;DR

This was accidentally [removed](https://github.com/reddit/edgecontext/commit/6b6bc585a9d03c735e99324e1d265bed67279041#diff-9a189e454032d0fd2d203297ec80ba9d4fa20212ea6d6a6635aea3677ba53720L63) from the public API, adding it back in.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] ~Contributor License Agreement (CLA) completed if not a Reddit employee~
