### PR TITLE
Swap thrift-unofficial for thrift

### DIFF
--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         "baseplate>=1.5,<3.0",
         "pyjwt>=2.0.0,<3.0",
-        "thrift-unofficial>=0.14,<1.0",
+        "thrift>=0.14,<1.0",
         "cryptography>=3.0",
     ],
     package_data={"reddit_edgecontext": ["py.typed"]},


### PR DESCRIPTION
## 💸 TL;DR
thrift-unofficial is no longer needed, as thrift publishes to pypi frequently. moreover, thrift-unofficial has not been published in quite some time

## 📜 Details
This PR should theoretically do absolutely nothing except modify which pypi is pulled.

## 🧪 Testing Steps / Validation
N/A

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
